### PR TITLE
Rollcall Integration to have versioned indices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,10 @@ DC_REGISTRY_URL=https://dc.dev.argo.cancercollaboratory.org/
 DC_ID=song.collab
 DC_URL=https://song.rdpc.cancercollaboratory.org/
 DC_BATCH_SIZE=50
+
+#############
+#  Rollcall #
+#############
+ROLLCALL_URL=http://localhost:9001
+ROLLCALL_FILE_ALIAS=file_centric
+ROLLCALL_FILE_ENTITY=file

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -31,10 +31,6 @@ services:
       MONGODB_PASSWORD: password
       MONGODB_DATABASE: files
       MONGODB_ROOT_PASSWORD: password123
-  zookeeper:
-    image: wurstmeister/zookeeper
-    ports:
-      - 2181:2181
 
   ################################
   ####  Elastic containers    ####
@@ -57,9 +53,29 @@ services:
     ports:
       - 5601:5601
 
+  rollcall:
+    image: overture/rollcall:2.6.0
+    depends_on:
+      - elasticsearch
+    ports:
+      - '9001:9001'
+    environment:
+      ELASTICSEARCH_NODE: http://elasticsearch:9200
+      SPRING_PROFILES_ACTIVE: test
+      SERVER_PORT: 9001
+      ROLLCALL_ALIASES_0_ALIAS: file_centric
+      ROLLCALL_ALIASES_0_ENTITY: file
+      ROLLCALL_ALIASES_0_TYPE: centric
+      SPRING_CLOUD_VAULT_ENABLED: 'false'
+
   ################################
   ####    KAFKA containers    ####
   ################################
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - 2181:2181
+
   # see : https://docs.confluent.io/current/quickstart/ce-docker-quickstart.html#ce-docker-quickstart
   broker:
     image: confluentinc/cp-kafka:5.4.0

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -66,6 +66,7 @@ services:
       ROLLCALL_ALIASES_0_ALIAS: file_centric
       ROLLCALL_ALIASES_0_ENTITY: file
       ROLLCALL_ALIASES_0_TYPE: centric
+      ROLLCALL_ALIASES_0_RELEASEROTATION: 2
       SPRING_CLOUD_VAULT_ENABLED: 'false'
 
   ################################

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,11 @@ export interface AppConfig {
     fetchTimeout: number;
     batchSize: number;
   };
+  rollcall: {
+    url: string;
+    aliasName: string;
+    entity: string;
+  };
   debug: {
     endpointsEnabled: boolean;
   };
@@ -151,6 +156,11 @@ const buildAppConfig = async (secrets: any): Promise<AppConfig> => {
       url: process.env.DC_URL || '',
       fetchTimeout: Number(process.env.DC_FETCH_TIMEOUT || 300 * 1000),
       batchSize: Number(process.env.DC_BATCH_SIZE || 50),
+    },
+    rollcall: {
+      url: process.env.ROLLCALL_URL || 'http://localhost:9001',
+      aliasName: process.env.ROLLCALL_FILE_ALIAS || 'file_service_placeholder_alias',
+      entity: process.env.ROLLCALL_FILE_ENTITY || 'fileserviceplaceholder',
     },
     debug: {
       endpointsEnabled: process.env.ENABLE_DEBUG_ENDPOINTS === 'true', // false unless set to 'true'

--- a/src/data/files/file.model.ts
+++ b/src/data/files/file.model.ts
@@ -212,7 +212,10 @@ export async function updateByObjectId(
   updates: mongoose.UpdateQuery<FileMongooseDocument>,
   options: any,
 ) {
-  return await FileModel.findOneAndUpdate({ objectId }, updates, options);
+  return await FileModel.findOneAndUpdate({ objectId }, updates, {
+    ...options,
+    useFindAndModify: false,
+  });
 }
 
 export async function updateBulk(

--- a/src/external/elasticsearch.ts
+++ b/src/external/elasticsearch.ts
@@ -27,7 +27,9 @@ import logger from '../logger';
 let esClient: Client;
 
 export async function getClient() {
-  if (esClient) return esClient;
+  if (esClient) {
+    return esClient;
+  }
   const config = await getAppConfig();
   esClient = new Client({
     node: config.elasticProperties.node,

--- a/src/external/elasticsearch.ts
+++ b/src/external/elasticsearch.ts
@@ -25,7 +25,6 @@ import esMapping from '../resources/file_centric_example.json';
 import logger from '../logger';
 
 let esClient: Client;
-let indexName: string = '';
 
 export async function getClient() {
   if (esClient) return esClient;
@@ -38,12 +37,6 @@ export async function getClient() {
     },
   });
   await esClient.ping();
-  indexName = config.elasticProperties.indexName;
-  if (config.elasticProperties.createSampleIndex) {
-    await createSampleIndex(indexName, esClient);
-  } else {
-    await checkIndexExists(indexName, esClient);
-  }
   return esClient;
 }
 

--- a/src/external/rollcall.ts
+++ b/src/external/rollcall.ts
@@ -21,6 +21,7 @@ import fetch from 'node-fetch';
 import urljoin from 'url-join';
 
 import logger from '../logger';
+import { AppConfig } from '../config';
 
 // Rollcall builds the index name as `entity_type_shardPrefix_shard_releasePrefix_release`,
 // release is not in the request because rollcall will calculate it
@@ -64,18 +65,12 @@ const RELEASE = {
   RESTRICTED: 'restricted',
 };
 
-export default (config: {
-  url: string;
-  aliasName: string;
-  entity: string;
-  type: string;
-  shardPrefix: string;
-}): RollCallClient => {
-  const rootUrl = config.url;
-  const aliasName = config.aliasName || 'file_centric';
-  const indexEntity = config?.entity || 'file';
-  const indexType = config?.type || 'centric';
-  const shardPrefix = config?.shardPrefix || 'program';
+export default (config: AppConfig): RollCallClient => {
+  const rootUrl = config.rollcall.url;
+  const aliasName = config.rollcall.aliasName;
+  const indexEntity = config.rollcall.entity;
+  const indexType = 'centric';
+  const shardPrefix = 'program';
 
   const fetchNextIndex = async (
     programShortName: string,

--- a/src/file-centric-index-mapping.json
+++ b/src/file-centric-index-mapping.json
@@ -1,0 +1,593 @@
+{
+  "settings": {
+    "index.max_result_window": 300000,
+    "analysis": {
+      "analyzer": {
+        "autocomplete_analyzer": {
+          "filter": ["lowercase", "edge_ngram"],
+          "tokenizer": "standard"
+        },
+        "autocomplete_prefix": {
+          "filter": ["lowercase", "edge_ngram"],
+          "tokenizer": "keyword"
+        },
+        "lowercase_keyword": {
+          "filter": ["lowercase"],
+          "tokenizer": "keyword"
+        }
+      },
+      "filter": {
+        "edge_ngram": {
+          "max_gram": 20,
+          "min_gram": 2,
+          "side": "front",
+          "type": "edge_ngram"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "analysis": {
+        "properties": {
+          "analysis_id": {
+            "type": "keyword",
+            "copy_to": ["file_autocomplete"]
+          },
+          "analysis_type": {
+            "type": "keyword"
+          },
+          "analysis_state": {
+            "type": "keyword"
+          },
+          "analysis_version": {
+            "type": "integer"
+          },
+          "updated_at": {
+            "type": "date"
+          },
+          "first_published_at": {
+            "type": "date"
+          },
+          "published_at": {
+            "type": "date"
+          },
+          "experiment": {
+            "properties": {
+              "experimental_strategy": {
+                "type": "keyword"
+              },
+              "platform": {
+                "type": "keyword"
+              }
+            }
+          },
+          "variant_class": {
+            "type": "keyword"
+          },
+          "workflow": {
+            "properties": {
+              "workflow_name": {
+                "type": "keyword"
+              },
+              "workflow_version": {
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      },
+      "analysis_tools": {
+        "type": "keyword",
+        "copy_to": ["file_autocomplete"]
+      },
+      "clinical": {
+        "properties": {
+          "donor": {
+            "properties": {
+              "age_at_menarche": {
+                "type": "integer"
+              },
+              "bmi": {
+                "type": "integer"
+              },
+              "cause_of_death": {
+                "type": "keyword"
+              },
+              "donor_id": {
+                "type": "keyword"
+              },
+              "height": {
+                "type": "integer"
+              },
+              "menopause_status": {
+                "type": "keyword"
+              },
+              "number_of_children": {
+                "type": "integer"
+              },
+              "number_of_pregnancies": {
+                "type": "integer"
+              },
+              "primary_site": {
+                "type": "keyword"
+              },
+              "submitter_donor_id": {
+                "type": "keyword"
+              },
+              "survival_time": {
+                "type": "integer"
+              },
+              "vital_status": {
+                "type": "keyword"
+              },
+              "weight": {
+                "type": "integer"
+              }
+            }
+          },
+          "follow_ups": {
+            "type": "nested",
+            "properties": {
+              "anatomic_site_progression_or_recurrences": {
+                "type": "keyword"
+              },
+              "disease_status_at_followup": {
+                "type": "keyword"
+              },
+              "follow_up_id": {
+                "type": "keyword"
+              },
+              "interval_of_followup": {
+                "type": "integer"
+              },
+              "is_primary_treatment": {
+                "type": "keyword"
+              },
+              "method_of_progression_status": {
+                "type": "keyword"
+              },
+              "posttherapy_m_category": {
+                "type": "keyword"
+              },
+              "posttherapy_n_category": {
+                "type": "keyword"
+              },
+              "posttherapy_stage_group": {
+                "type": "keyword"
+              },
+              "posttherapy_t_category": {
+                "type": "keyword"
+              },
+              "posttherapy_tumour_staging_system": {
+                "type": "keyword"
+              },
+              "primary_diagnosis_id": {
+                "type": "keyword"
+              },
+              "recurrence_m_category": {
+                "type": "keyword"
+              },
+              "recurrence_n_category": {
+                "type": "keyword"
+              },
+              "recurrence_stage_group": {
+                "type": "keyword"
+              },
+              "recurrence_t_category": {
+                "type": "keyword"
+              },
+              "recurrence_tumour_staging_system": {
+                "type": "keyword"
+              },
+              "relapse_interval": {
+                "type": "integer"
+              },
+              "relapse_type": {
+                "type": "keyword"
+              },
+              "submitter_follow_up_id": {
+                "type": "keyword"
+              },
+              "submitter_primary_diagnosis_id": {
+                "type": "keyword"
+              },
+              "submitter_treatment_id": {
+                "type": "keyword"
+              },
+              "treatment_id": {
+                "type": "keyword"
+              },
+              "treatment_type": {
+                "type": "keyword"
+              },
+              "weight_at_followup": {
+                "type": "integer"
+              }
+            }
+          },
+          "primary_diagnosis": {
+            "type": "nested",
+            "properties": {
+              "age_at_diagnosis": {
+                "type": "integer"
+              },
+              "basis_of_diagnosis": {
+                "type": "keyword"
+              },
+              "cancer_type_additional_information": {
+                "type": "keyword"
+              },
+              "cancer_type_code": {
+                "type": "keyword"
+              },
+              "clinical_m_category": {
+                "type": "keyword"
+              },
+              "clinical_n_category": {
+                "type": "keyword"
+              },
+              "clinical_stage_group": {
+                "type": "keyword"
+              },
+              "clinical_t_category": {
+                "type": "keyword"
+              },
+              "clinical_tumour_staging_system": {
+                "type": "keyword"
+              },
+              "number_lymph_nodes_examined": {
+                "type": "integer"
+              },
+              "number_lymph_nodes_positive": {
+                "type": "integer"
+              },
+              "performance_status": {
+                "type": "keyword"
+              },
+              "presenting_symptoms": {
+                "type": "keyword"
+              },
+              "primary_diagnosis_id": {
+                "type": "keyword"
+              },
+              "submitter_primary_diagnosis_id": {
+                "type": "keyword"
+              }
+            }
+          },
+          "specimens": {
+            "type": "nested",
+            "properties": {
+              "pathological_m_category": {
+                "type": "keyword"
+              },
+              "pathological_n_category": {
+                "type": "keyword"
+              },
+              "pathological_stage_group": {
+                "type": "keyword"
+              },
+              "pathological_t_category": {
+                "type": "keyword"
+              },
+              "pathological_tumour_staging_system": {
+                "type": "keyword"
+              },
+              "percent_inflammatory_tissue": {
+                "type": "float"
+              },
+              "percent_necrosis": {
+                "type": "float"
+              },
+              "percent_proliferating_cells": {
+                "type": "float"
+              },
+              "percent_stromal_cells": {
+                "type": "float"
+              },
+              "percent_tumour_cells": {
+                "type": "float"
+              },
+              "primary_diagnosis_id": {
+                "type": "keyword"
+              },
+              "reference_pathology_confirmed": {
+                "type": "keyword"
+              },
+              "specimen_acquisition_interval": {
+                "type": "integer"
+              },
+              "specimen_anatomic_location": {
+                "type": "keyword"
+              },
+              "specimen_id": {
+                "type": "keyword"
+              },
+              "specimen_processing": {
+                "type": "keyword"
+              },
+              "specimen_storage": {
+                "type": "keyword"
+              },
+              "submitter_primary_diagnosis_id": {
+                "type": "keyword"
+              },
+              "submitter_specimen_id": {
+                "type": "keyword"
+              },
+              "tumour_grade": {
+                "type": "keyword"
+              },
+              "tumour_grading_system": {
+                "type": "keyword"
+              },
+              "tumour_histological_type": {
+                "type": "keyword"
+              }
+            }
+          },
+          "treatments": {
+            "type": "nested",
+            "properties": {
+              "adverse_events": {
+                "type": "keyword"
+              },
+              "anatomical_site_irradiated": {
+                "type": "keyword"
+              },
+              "chemotherapy_dosage_units": {
+                "type": "keyword"
+              },
+              "clinical_trial_number": {
+                "type": "keyword"
+              },
+              "clinical_trials_database": {
+                "type": "keyword"
+              },
+              "cumulative_drug_dosage": {
+                "type": "float"
+              },
+              "days_per_cycle": {
+                "type": "integer"
+              },
+              "drug_name": {
+                "type": "keyword"
+              },
+              "drug_rxnormcui": {
+                "type": "keyword"
+              },
+              "hemotological_toxicity": {
+                "type": "keyword"
+              },
+              "hormone_drug_dosage_units": {
+                "type": "keyword"
+              },
+              "is_primary_treatment": {
+                "type": "keyword"
+              },
+              "line_of_treatment": {
+                "type": "integer"
+              },
+              "number_of_cycles": {
+                "type": "integer"
+              },
+              "outcome_of_treatment": {
+                "type": "keyword"
+              },
+              "primary_diagnosis_id": {
+                "type": "keyword"
+              },
+              "radiation_therapy_dosage": {
+                "type": "integer"
+              },
+              "radiation_therapy_fractions": {
+                "type": "integer"
+              },
+              "radiation_therapy_modality": {
+                "type": "keyword"
+              },
+              "radiation_therapy_type": {
+                "type": "keyword"
+              },
+              "response_to_treatment": {
+                "type": "keyword"
+              },
+              "submitter_primary_diagnosis_id": {
+                "type": "keyword"
+              },
+              "submitter_treatment_id": {
+                "type": "keyword"
+              },
+              "toxicity_type": {
+                "type": "keyword"
+              },
+              "treatment_duration": {
+                "type": "integer"
+              },
+              "treatment_id": {
+                "type": "keyword"
+              },
+              "treatment_intent": {
+                "type": "keyword"
+              },
+              "treatment_setting": {
+                "type": "keyword"
+              },
+              "treatment_start_interval": {
+                "type": "integer"
+              },
+              "treatment_type": {
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      },
+      "data_category": {
+        "type": "keyword",
+        "copy_to": ["file_autocomplete"]
+      },
+      "data_type": {
+        "type": "keyword",
+        "copy_to": ["file_autocomplete"]
+      },
+      "donors": {
+        "type": "nested",
+        "properties": {
+          "donor_id": {
+            "type": "keyword",
+            "copy_to": ["file_autocomplete"]
+          },
+          "gender": {
+            "type": "keyword"
+          },
+          "specimens": {
+            "type": "nested",
+            "properties": {
+              "samples": {
+                "type": "nested",
+                "properties": {
+                  "matched_normal_submitter_sample_id": {
+                    "type": "keyword",
+                    "copy_to": ["file_autocomplete"]
+                  },
+                  "sample_id": {
+                    "type": "keyword",
+                    "copy_to": ["file_autocomplete"]
+                  },
+                  "sample_type": {
+                    "type": "keyword"
+                  },
+                  "submitter_sample_id": {
+                    "type": "keyword",
+                    "copy_to": ["file_autocomplete"]
+                  }
+                }
+              },
+              "specimen_id": {
+                "type": "keyword",
+                "copy_to": ["file_autocomplete"]
+              },
+              "specimen_tissue_source": {
+                "type": "keyword"
+              },
+              "specimen_type": {
+                "type": "keyword"
+              },
+              "submitter_specimen_id": {
+                "type": "keyword",
+                "copy_to": ["file_autocomplete"]
+              },
+              "tumour_normal_designation": {
+                "type": "keyword"
+              }
+            }
+          },
+          "submitter_donor_id": {
+            "type": "keyword",
+            "copy_to": ["file_autocomplete"]
+          }
+        }
+      },
+      "file": {
+        "type": "nested",
+        "properties": {
+          "index_file": {
+            "type": "nested",
+            "properties": {
+              "file_type": {
+                "type": "keyword"
+              },
+              "md5sum": {
+                "type": "keyword"
+              },
+              "name": {
+                "type": "keyword"
+              },
+              "object_id": {
+                "type": "keyword"
+              },
+              "size": {
+                "type": "long"
+              }
+            }
+          },
+          "md5sum": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword",
+            "copy_to": ["file_autocomplete"]
+          },
+          "size": {
+            "type": "long"
+          }
+        }
+      },
+      "file_access": {
+        "type": "keyword"
+      },
+      "file_autocomplete": {
+        "type": "keyword",
+        "fields": {
+          "analyzed": {
+            "type": "text",
+            "analyzer": "autocomplete_analyzer",
+            "search_analyzer": "lowercase_keyword"
+          },
+          "lowercase": {
+            "type": "text",
+            "analyzer": "lowercase_keyword"
+          },
+          "prefix": {
+            "type": "text",
+            "analyzer": "autocomplete_prefix",
+            "search_analyzer": "lowercase_keyword"
+          }
+        }
+      },
+      "file_id": {
+        "type": "keyword",
+        "copy_to": ["file_autocomplete"]
+      },
+      "file_type": {
+        "type": "keyword"
+      },
+      "object_id": {
+        "type": "keyword",
+        "copy_to": ["file_autocomplete"]
+      },
+      "program_access_date": {
+        "type": "date"
+      },
+      "release_stage": {
+        "type": "keyword"
+      },
+      "repositories": {
+        "type": "nested",
+        "properties": {
+          "code": {
+            "type": "keyword"
+          },
+          "country": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          },
+          "organization": {
+            "type": "keyword"
+          },
+          "url": {
+            "type": "keyword"
+          }
+        }
+      },
+      "study_id": {
+        "type": "keyword",
+        "copy_to": ["file_autocomplete"]
+      }
+    }
+  }
+}

--- a/src/services/fileManager.ts
+++ b/src/services/fileManager.ts
@@ -6,7 +6,7 @@ import { FilePartialDocument } from '../external/analysisConverter';
 import * as fileService from '../data/files';
 import { buildDocument, FileCentricDocument } from './fileCentricDocument';
 import { getEmbargoStage } from './embargo';
-import * as indexer from './indexer';
+import { getIndexer, Indexer } from './indexer';
 import logger from '../logger';
 
 export async function updateFileFromRdpcData(
@@ -51,6 +51,7 @@ type SaveAndIndexResults = {
 export async function saveAndIndexFilesFromRdpcData(
   filePartialDocuments: FilePartialDocument[],
   dataCenterId: string,
+  indexer: Indexer,
 ): Promise<SaveAndIndexResults> {
   const fileCentricDocuments = await Promise.all(
     filePartialDocuments.map(async filePartialDocument => {
@@ -70,15 +71,16 @@ export async function saveAndIndexFilesFromRdpcData(
   );
 
   if (addDocuments.length) {
-    await indexer.index(addDocuments);
+    await indexer.indexFiles(addDocuments);
   }
   if (removeDocuments.length) {
-    await indexer.remove(removeDocuments);
+    await indexer.removeFiles(removeDocuments);
   }
+
   // Note: the indexed documents have had all property keys converted to snake case,
   //       so file_id for indexed docs and fileId for removed docs
   return {
-    indexed: addDocuments.map(doc => doc.file_id),
+    indexed: addDocuments.map(doc => doc.objectId),
     removed: removeDocuments.map(doc => doc.fileId),
   };
 }

--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -39,7 +39,7 @@ export const getIndexer = async (options?: { doClone: boolean }) => {
   // Default doClone to true.
   const doClone = options ? options.doClone : true;
 
-  const rollcall = getRollcall(await getAppConfig());
+  const rollcall = await getRollcall();
 
   type IndexNameHolder = {
     public: { [programId: string]: Index };
@@ -137,7 +137,7 @@ export const getIndexer = async (options?: { doClone: boolean }) => {
             body,
           });
         } catch (e) {
-          logger.error(`failed bulk indexing request: ${JSON.stringify(e)}`, e);
+          logger.error(`Failed bulk indexing request: ${JSON.stringify(e)}`, e);
           throw e;
         }
       });
@@ -160,7 +160,7 @@ export const getIndexer = async (options?: { doClone: boolean }) => {
             body,
           });
         } catch (e) {
-          logger.error(`failed bulk delete request: ${JSON.stringify(e)}`, e);
+          logger.error(`Failed bulk delete request: ${JSON.stringify(e)}`, e);
           throw e;
         }
       });

--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -103,7 +103,6 @@ export const getIndexer = async (options?: { doClone: boolean }) => {
       release_state: file.releaseState,
     };
 
-    // TODO: get indexName from rollcall
     const client = await getClient();
     await client.update({
       index: await getIndexName(file.programId, false),
@@ -112,13 +111,11 @@ export const getIndexer = async (options?: { doClone: boolean }) => {
     });
   }
 
-  // TODO: Split the docs into programs then bulk index for each program
   async function indexFiles(docs: FileCentricDocument[]) {
     const sortedFiles = sortFilesIntoPrograms(docs);
 
     const client = await getClient();
 
-    // TODO: configure concurrency for ES requests.
     PromisePool.withConcurrency(20)
       .for(sortedFiles)
       .process(async ({ program, files }) => {

--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -17,67 +17,162 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import PromisePool from '@supercharge/promise-pool';
+
 import logger from '../logger';
 import { getClient } from '../external/elasticsearch';
 import { getAppConfig } from '../config';
 import { FileCentricDocument } from './fileCentricDocument';
 import { File } from '../data/files';
+import getRollcall, { Index } from '../external/rollcall';
 
-const getIndexName = async () => {
-  return (await getAppConfig()).elasticProperties.indexName;
+type ReleaseOptions = {
+  publicRelease: boolean;
 };
+export interface Indexer {
+  updateFile: (file: File) => Promise<void>;
+  indexFiles: (docs: FileCentricDocument[]) => Promise<void>;
+  removeFiles: (docs: FileCentricDocument[]) => Promise<void>;
+  release: (options?: ReleaseOptions) => Promise<void>;
+}
+export const getIndexer = async (options?: { doClone: boolean }) => {
+  // Default doClone to true.
+  const doClone = options ? options.doClone : true;
 
-export async function updateDocFromFile(file: File) {
-  // updates for the file in ES
-  const doc = {
-    embargo_stage: file.embargoStage,
-    release_state: file.releaseState,
+  const rollcall = getRollcall(await getAppConfig());
+
+  type IndexNameHolder = {
+    public: { [programId: string]: Index };
+    restricted: { [programId: string]: Index };
+  };
+  const resolvedIndices: IndexNameHolder = {
+    public: {},
+    restricted: {},
   };
 
-  // TODO: get indexName from rollcall
-  const client = await getClient();
-  await client.update({
-    index: await getIndexName(),
-    id: file.objectId,
-    body: { doc },
-  });
-}
+  const getIndexName = async (program: string, isPublic: boolean): Promise<string> => {
+    const publicIdentifier = isPublic ? 'public' : 'restricted'; // for choosing correct section of resolvedIndices
 
-export async function index(docs: FileCentricDocument[]) {
-  const client = await getClient();
-  const body = docs.map(camelCaseKeysToUnderscore).flatMap(doc => [
-    { update: { _id: doc.object_id } },
-    {
-      doc_as_upsert: true,
-      doc,
-    },
-  ]);
+    const existingIndex: Index | undefined = resolvedIndices[publicIdentifier][program];
+    if (existingIndex) {
+      return existingIndex.indexName;
+    }
 
-  try {
-    await client.bulk({
-      index: await getIndexName(),
-      body,
+    // Index hasn't been fetched yet, lets go grab it.
+    const nextIndex = await rollcall.fetchNextIndex(program, {
+      isPublic,
+      cloneFromReleasedIndex: doClone,
     });
-  } catch (e) {
-    logger.error(`failed bulk indexing request: ${JSON.stringify(e)}`, e);
-    throw e;
+    resolvedIndices[publicIdentifier][program] = nextIndex;
+    return nextIndex.indexName;
+  };
+
+  async function release(options?: ReleaseOptions) {
+    // Default publicRelease to false;
+    const publicRelease = options ? options.publicRelease : false;
+
+    const toRelease = Object.values(resolvedIndices.restricted);
+    if (publicRelease) {
+      toRelease.concat(Object.values(resolvedIndices.public));
+    }
+
+    // TODO: config for max simultaneous release?
+    await PromisePool.withConcurrency(5)
+      .for(toRelease)
+      .handleError((error, index) => {
+        logger.error(`Failed to release index: ${index.indexName}`);
+      })
+      .process(async indexName => {
+        await rollcall.release(indexName);
+      });
+    // Clear stored index names to prevent repeat releases.
+    resolvedIndices.public = {};
+    resolvedIndices.restricted = {};
   }
-}
 
-export async function remove(docs: { [k: string]: any; objectId: string }[]) {
-  const client = await getClient();
-  const body = docs.map(doc => ({ delete: { _id: doc.objectId } }));
+  /**
+   * Update the parts of the file managed by this service:
+   *   - embargo_stage
+   *   - release_state
+   * @param file
+   */
+  async function updateFile(file: File) {
+    // updates for the file in ES
+    const doc = {
+      embargo_stage: file.embargoStage,
+      release_state: file.releaseState,
+    };
 
-  try {
-    await client.bulk({
-      index: await getIndexName(),
-      body,
+    // TODO: get indexName from rollcall
+    const client = await getClient();
+    await client.update({
+      index: await getIndexName(file.programId, false),
+      id: file.objectId,
+      body: { doc },
     });
-  } catch (e) {
-    logger.error(`failed bulk delete request: ${JSON.stringify(e)}`, e);
-    throw e;
   }
-}
+
+  // TODO: Split the docs into programs then bulk index for each program
+  async function indexFiles(docs: FileCentricDocument[]) {
+    const sortedFiles = sortFilesIntoPrograms(docs);
+
+    const client = await getClient();
+
+    // TODO: configure concurrency for ES requests.
+    PromisePool.withConcurrency(20)
+      .for(sortedFiles)
+      .process(async ({ program, files }) => {
+        const index = await getIndexName(program, false);
+        const body = files.map(camelCaseKeysToUnderscore).flatMap(doc => [
+          { update: { _id: doc.object_id } },
+          {
+            doc_as_upsert: true,
+            doc,
+          },
+        ]);
+
+        try {
+          await client.bulk({
+            index,
+            body,
+          });
+        } catch (e) {
+          logger.error(`failed bulk indexing request: ${JSON.stringify(e)}`, e);
+          throw e;
+        }
+      });
+  }
+
+  async function removeFiles(docs: FileCentricDocument[]) {
+    const sortedFiles = sortFilesIntoPrograms(docs);
+
+    const client = await getClient();
+
+    // TODO: configure concurrency for ES requests.
+    PromisePool.withConcurrency(20)
+      .for(sortedFiles)
+      .process(async ({ program, files }) => {
+        const body = docs.map(doc => ({ delete: { _id: doc.objectId } }));
+
+        try {
+          await client.bulk({
+            index: await getIndexName(program, false),
+            body,
+          });
+        } catch (e) {
+          logger.error(`failed bulk delete request: ${JSON.stringify(e)}`, e);
+          throw e;
+        }
+      });
+  }
+
+  return {
+    updateFile,
+    indexFiles,
+    removeFiles,
+    release,
+  };
+};
 
 function camelCaseKeysToUnderscore(obj: any) {
   if (typeof obj != 'object') return obj;
@@ -101,4 +196,26 @@ function camelCaseKeysToUnderscore(obj: any) {
     }
   }
   return obj;
+}
+// Separate list of file documents into distinct list per program.
+type FilesSortedByProgramsArray = Array<{ files: FileCentricDocument[]; program: string }>;
+function sortFilesIntoPrograms(files: FileCentricDocument[]): FilesSortedByProgramsArray {
+  const output: FilesSortedByProgramsArray = [];
+
+  // Sort Files into programs
+  const programMap = files.reduce((acc: { [program: string]: FileCentricDocument[] }, file) => {
+    const program = file.studyId;
+    if (acc[program]) {
+      acc[program].push(file);
+    } else {
+      acc[program] = [file];
+    }
+    return acc;
+  }, {});
+
+  // For each program, add an element to output array
+  Object.entries(programMap).forEach(([program, files]) => {
+    output.push({ program, files });
+  });
+  return output;
 }

--- a/src/test/.env.test
+++ b/src/test/.env.test
@@ -41,3 +41,10 @@ CREATE_SAMPLE_INDEX=true
 #  Maestro #
 ############
 ANALYSIS_CONVERTER_URL=http://maestro.org/convert
+
+#############
+#  Rollcall #
+#############
+ROLLCALL_URL=http://localhost:9001
+ROLLCALL_FILE_ALIAS=file_centric_test
+ROLLCALL_FILE_ENTITY=file

--- a/src/test/analysisEventHandler.spec.ts
+++ b/src/test/analysisEventHandler.spec.ts
@@ -27,7 +27,7 @@ import * as db from '../data/dbConnection';
 import { getAppConfig } from '../config';
 const ES_PORT = 9200;
 
-describe('manager', () => {
+describe('analysisEventHandler', () => {
   let esClient: Client;
   let esContainer: StartedTestContainer;
   let mongoContainer: StartedTestContainer;


### PR DESCRIPTION
Indices can now be created and released using Rollcall. This provides the file service with the ability to maintain one index per program, and separate public and restricted data.

The planned file-centric mapping, based on the maestro analysis shape with clinical data fields added, was introduced. Each index provided through the rollcall service will come preloaded with this mapping.