### PR TITLE
Correctly Check PUBLIC release state

### DIFF
--- a/src/services/fileManager.ts
+++ b/src/services/fileManager.ts
@@ -45,6 +45,7 @@ import Logger from '../logger';
 import { getDataCenter } from '../external/dataCenterRegistry';
 import PromisePool from '@supercharge/promise-pool/dist';
 import { ANALYSIS_STATE } from '../utils/constants';
+import { isPublic } from './utils/fileUtils';
 const logger = Logger('FileManager');
 
 export async function updateFileFromRdpcData(
@@ -136,14 +137,14 @@ export async function recalculateFileState(file: File) {
   // If the file is not already released, lets update its embargo stage
   const updates: { embargoStage?: EmbargoStage; releaseState?: FileReleaseState } = {};
   const embargoStage = getEmbargoStage(file);
-  if (file.releaseState === FileReleaseState.PUBLIC) {
+  if (isPublic(file)) {
     if (embargoStage !== EmbargoStage.PUBLIC) {
       // A currently public file has been calculated as needing to be restricted
       // Record the calculated embargoStage but the file remains correctly listed as releaseState = PUBLIC
       logger.debug(
         'recalculateFileState()',
         file.fileId,
-        'PUBLIC file embargo calculated to be',
+        `${file.releaseState} file embargo calculated to be`,
         embargoStage,
         'Setting release state to',
         FileReleaseState.QUEUE_TO_RESTRICTED,

--- a/src/services/utils/fileUtils.ts
+++ b/src/services/utils/fileUtils.ts
@@ -1,0 +1,8 @@
+import { File, FileReleaseState } from '../../data/files';
+import { FileCentricDocument } from '../fileCentricDocument';
+
+export const isPublic = (file: File | FileCentricDocument): boolean =>
+  [FileReleaseState.PUBLIC, FileReleaseState.QUEUE_TO_RESTRICTED].includes(file.releaseState);
+
+export const isRestricted = (file: File | FileCentricDocument): boolean =>
+  [FileReleaseState.RESTRICTED, FileReleaseState.QUEUE_TO_PUBLIC].includes(file.releaseState);


### PR DESCRIPTION
Introduces two utility methods `isPublic` and `isRestricted` that will check the file release state vs the full set of states. This is necessary since we added a second state that is considered "PUBLIC" (queued to restrict).

An additional small fix was added to song analysis event processor to not release a copied restricted index when no restricted files are affected.