### PR TITLE
🐛 Stop cloning restricted indices on re-index requests

### DIFF
--- a/src/jobs/reindexDataCenter.ts
+++ b/src/jobs/reindexDataCenter.ts
@@ -40,15 +40,13 @@ async function reindexDataCenter(dataCenterId: string, studyFilter: string[]) {
     const { url } = await getDataCenter(dataCenterId);
     logger.info(`Datacenter URL: ${url}`);
     const studies: string[] = await getStudies(url);
+    const filteredStudies: string[] =
+      studyFilter.length > 0 ? studies.filter(study => studyFilter.includes(study)) : studies;
 
     const indexer = await getIndexer();
+    await indexer.createEmptyRestrictedIndices(filteredStudies);
 
-    for (const study of studies) {
-      if (studyFilter.length > 0 && !studyFilter.includes(study)) {
-        // Skip studies not in our requested list
-        logger.debug(`Skipping study not included in re-index request: ${study}`);
-        continue;
-      }
+    for (const study of filteredStudies) {
       logger.info(`Indexing study: ${study}`);
       try {
         const analysesStream = await generateStudyAnalyses(url, study);

--- a/src/routers/admin.ts
+++ b/src/routers/admin.ts
@@ -52,7 +52,10 @@ const createAdminRouter = (config: AppConfig, authFilter: (scopes: string[]) => 
       // const dataCenterId = req.params.datacenter;
       // TODO: Current config hardcodes a single data center instead of retrieving connection details from data center registry
 
-      const studies: string[] = (req.query.study || []) as string[];
+      // Swagger UI isn't sending single studies as an array, so we need to parse it
+      const studies: string[] = ((typeof req.query.study === 'string'
+        ? [req.query.study]
+        : req.query.study) || []) as string[];
 
       const dataCenterId = config.datacenter.dataCenterId;
       reindexDataCenter(dataCenterId, studies);

--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -47,7 +47,8 @@ export interface Indexer {
   removeFilesFromPublic: (files: File[]) => Promise<void>;
   removeFilesFromRestricted: (files: File[]) => Promise<void>;
 
-  preparePublicIndices: (programs: string[]) => Promise<string[]>;
+  createEmptyPublicIndices: (programs: string[]) => Promise<string[]>;
+  createEmptyRestrictedIndices: (programs: string[]) => Promise<string[]>;
   indexPublicFileDocs: (docs: FileCentricDocument[]) => Promise<void>;
   deleteIndices: (indices: string[]) => Promise<void>;
 
@@ -313,7 +314,7 @@ export const getIndexer = async (): Promise<Indexer> => {
       });
   }
 
-  async function preparePublicIndices(programs: string[]): Promise<string[]> {
+  async function createEmptyPublicIndices(programs: string[]): Promise<string[]> {
     const publicIndices: string[] = [];
     await PromisePool.withConcurrency(5)
       .for(programs)
@@ -322,6 +323,17 @@ export const getIndexer = async (): Promise<Indexer> => {
         publicIndices.push(index);
       });
     return publicIndices;
+  }
+
+  async function createEmptyRestrictedIndices(programs: string[]): Promise<string[]> {
+    const restrictedIndices: string[] = [];
+    await PromisePool.withConcurrency(5)
+      .for(programs)
+      .process(async program => {
+        const index = await getNextIndex(program, { isPublic: false, clone: false });
+        restrictedIndices.push(index);
+      });
+    return restrictedIndices;
   }
 
   /**
@@ -516,7 +528,8 @@ export const getIndexer = async (): Promise<Indexer> => {
     updateRestrictedFile,
 
     // Public Index Management
-    preparePublicIndices,
+    createEmptyPublicIndices,
+    createEmptyRestrictedIndices,
     indexPublicFileDocs,
     deleteIndices,
     removeFilesFromPublic,

--- a/src/services/release.ts
+++ b/src/services/release.ts
@@ -160,7 +160,7 @@ export async function buildActiveRelease(label: string): Promise<void> {
     release = await releaseService.updateActiveReleaseIndices([]);
 
     // 2.b Make new empty public indices from the current public indices.
-    const publicIndices = await indexer.preparePublicIndices(Array.from(programIds));
+    const publicIndices = await indexer.createEmptyPublicIndices(Array.from(programIds));
     release = await releaseService.updateActiveReleaseIndices(publicIndices);
 
     // 3. Add files all required files to public indices.


### PR DESCRIPTION
* Fixes an error where breaking mapping changes would cause re-index requests to fail