### PR TITLE
🐛 Prevent Indexing of Incorrect Metrics Data

### DIFF
--- a/src/external/analysisConverter.ts
+++ b/src/external/analysisConverter.ts
@@ -120,7 +120,8 @@ export async function convertAnalysisFileDocuments(
     .process(async (objectId: string) => {
       if (
         response[objectId][0].dataType === 'Aligned Reads' &&
-        response[objectId][0].analysis.analysisState === 'PUBLISHED'
+        response[objectId][0].analysis.analysisState === 'PUBLISHED' &&
+        response[objectId][0].analysis.workflow.workflow_name === 'DNA Seq Alignment'
       ) {
         const fileWithMetrics = await addMetricsToAlignedReadsFile(response, objectId);
         files.push(...fileWithMetrics);

--- a/src/external/dataCenterGateway/gql/ALIGNMENT_METRICS_BY_RUN_ID.ts
+++ b/src/external/dataCenterGateway/gql/ALIGNMENT_METRICS_BY_RUN_ID.ts
@@ -27,8 +27,9 @@ const ALIGNMENT_METRICS_BY_RUN_ID = gql`
         analysisState
         studyId
         analysisType
-        files {
+        files(filter: { analysisTools: ["Samtools:stats"] }) {
           fileType
+          analysisTools
           objectId
           metrics
         }


### PR DESCRIPTION
* Only index metrics from files generated by `Samtools:stats` during `DNA Seq Alignment` workflows