### PR TITLE
FileFilter properties combined with OR condition instead of implicit AND

### DIFF
--- a/src/data/files/file.service.ts
+++ b/src/data/files/file.service.ts
@@ -17,27 +17,26 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import _ from 'lodash';
+import Logger from '../../logger';
+import * as fileModel from './file.model';
 import {
-  File,
-  FileInput,
-  FileMongooseDocument,
-  FileLabel,
-  FileFilter,
-  QueryFilters,
   EmbargoStage,
+  File,
+  FileFilter,
+  FileFilterProperties,
+  FileInput,
+  FileLabel,
+  FileMongooseDocument,
   FileReleaseState,
+  FilesResponse,
   FileStateFilter,
   PaginationFilter,
-  FilesResponse,
 } from './file.model';
-import * as fileModel from './file.model';
-import Logger from '../../logger';
 const logger = Logger('File.DataService');
 
 export async function getPaginatedFiles(
   paginationFilter: PaginationFilter,
-  queryFilter: QueryFilters,
+  queryFilter: FileFilterProperties,
 ): Promise<FilesResponse> {
   const response = await fileModel.getFilesQuery(paginationFilter, queryFilter);
   const files = response.docs.map(toPojo);

--- a/src/resources/swagger.yaml
+++ b/src/resources/swagger.yaml
@@ -54,29 +54,36 @@ paths:
           required: false
           schema:
             type: number
-        - name: analysisId
+        - name: analyses
           description: List of analysis ids, csv
           in: query
           required: false
           schema:
             type: string
             format: csv
-        - name: objectId
+        - name: objectIds
           description: List of file object Ids, csv
           in: query
           required: false
           schema:
             type: string
             format: csv
-        - name: programId
+        - name: programs
           description: List of file program Ids, csv
           in: query
           required: false
           schema:
             type: string
             format: csv
-        - name: donorId
+        - name: donors
           description: List of file donor Ids, csv
+          in: query
+          required: false
+          schema:
+            type: string
+            format: csv
+        - name: fileIds
+          description: List of file file Ids, csv
           in: query
           required: false
           schema:

--- a/src/routers/files.ts
+++ b/src/routers/files.ts
@@ -46,10 +46,11 @@ const createFilesRouter = (config: AppConfig, authFilter: (scopes: string[]) => 
             limit: (req.query as any)?.limit,
           },
           {
-            analysisId: (req.query as any)?.analysisId?.split(','),
-            objectId: (req.query as any)?.objectId?.split(','),
-            programId: (req.query as any)?.programId?.split(','),
-            donorId: (req.query as any)?.donorId?.split(','),
+            analyses: (req.query as any)?.analyses?.split(','),
+            objectIds: (req.query as any)?.objectIds?.split(','),
+            programs: (req.query as any)?.programs?.split(','),
+            donors: (req.query as any)?.donors?.split(','),
+            fileIds: (req.query as any)?.fileIds?.split(','),
           },
         ),
       );


### PR DESCRIPTION
FileFilter properties should be additive (ie. OR condition if multiple are provided). By default they apply an AND condition which doesn't work (for instance providing a whole program plus another file ID would give you no results).

Combining the FileFilter properties with an `$or` condition list,  and then combining the include and exclude lists with an `$and` condition achieves this.

Took this opportunity to standardize the `GET /files` query to use the same filter as the promote/demote admin methods.