### PR TITLE
🚧 Add Clinical Update Consumer (#25)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,10 +41,23 @@ KAFKA_MESSAGING_ENABLED=false
 # if messaging is set to false, values below don't need to be set
 KAFKA_CLIENT_ID=files-service
 KAFKA_BROKERS=localhost:9092
+
+## Consumers:
+# Analysis Updates
 KAFKA_ANALYSIS_UPDATES_TOPIC=song_analysis
-# the name of the dead letter queue topic (optional, if not specified, no dlq topic will be used)
-KAFKA_ANALYSIS_UPDATES_DLQ=files_svc_dlq
-KAFKA_REINDEXING_TOPIC=files_reindexing
+#KAFKA_ANLYSIS_UPDATES_GROUP=
+#KAFKA_ANALYSIS_UPDATES_DLQ=
+
+# Recalculate Embargo
+#KAFKA_RECALCULATE_EMBARGO_TOPIC=
+#KAFKA_RECALCULATE_EMBARGO_GROUP=
+
+# Clinical Data Updates
+KAFKA_CLINICAL_UPDATES_TOPIC=clinical_program_update
+#KAFKA_CLINICAL_UPDATES_GROUP=
+#KAFKA_CLINICAL_UPDATES_DLQ=
+
+## Producers:
 KAFKA_PUBLIC_RELEASE_TOPIC=files_public_release
 
 ############
@@ -97,3 +110,8 @@ ROLLCALL_FILE_ENTITY=file
 #  Clinical API #
 #################
 CLINICAL_URL=http://localhost:3000
+
+##################
+#  Feature Flags #
+##################
+FEATURE_CLINICAL_DATA_INDEXING=false

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,6 +80,9 @@ export interface AppConfig {
   debug: {
     endpointsEnabled: boolean;
   };
+  features: {
+    clinicalDataIndexing: boolean;
+  };
 }
 
 export interface KafkaConsumerConfiguration {
@@ -146,16 +149,16 @@ const buildAppConfig = async (secrets: any): Promise<AppConfig> => {
           group: process.env.KAFKA_ANLYSIS_UPDATES_GROUP || 'file-manager.group.analysis-updates',
           dlq: process.env.KAFKA_ANALYSIS_UPDATES_DLQ,
         },
+        clinicalUpdates: {
+          topic: process.env.KAFKA_CLINICAL_UPDATES_TOPIC || 'clinical_program_update',
+          group: process.env.KAFKA_CLINICAL_UPDATES_GROUP || 'file-manager.group.clinical-updates',
+          dlq: process.env.KAFKA_CLINICAL_UPDATES_DLQ,
+        },
         recalculateEmbargo: {
           topic: process.env.KAFKA_RECALCULATE_EMBARGO_TOPIC || 'file-manager.recalculate-embargo',
           group:
             process.env.KAFKA_RECALCULATE_EMBARGO_GROUP || 'file-manager.group.recalculate-embargo',
           // No need for DLQ. Failures will get corrected on next attempt if scheduled to run regularly.
-        },
-        clinicalUpdates: {
-          topic: process.env.KAFKA_ANALYSIS_UPDATES_TOPIC || 'clinical_program_update',
-          group: process.env.KAFKA_ANLYSIS_UPDATES_GROUP || 'file-manager.group.clinical-updates',
-          dlq: process.env.KAFKA_ANALYSIS_UPDATES_DLQ,
         },
       },
       producers: {
@@ -203,6 +206,9 @@ const buildAppConfig = async (secrets: any): Promise<AppConfig> => {
     },
     debug: {
       endpointsEnabled: process.env.ENABLE_DEBUG_ENDPOINTS === 'true', // false unless set to 'true'
+    },
+    features: {
+      clinicalDataIndexing: process.env.FEATURE_CLINICAL_DATA_INDEXING === 'true',
     },
   };
   return config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,7 @@ export interface AppConfig {
     consumers: {
       analysisUpdates: KafkaConsumerConfiguration;
       recalculateEmbargo: KafkaConsumerConfiguration;
+      clinicalUpdates: KafkaConsumerConfiguration;
     };
     producers: {
       publicRelease: KafkaProducerConfiguration;
@@ -150,6 +151,11 @@ const buildAppConfig = async (secrets: any): Promise<AppConfig> => {
           group:
             process.env.KAFKA_RECALCULATE_EMBARGO_GROUP || 'file-manager.group.recalculate-embargo',
           // No need for DLQ. Failures will get corrected on next attempt if scheduled to run regularly.
+        },
+        clinicalUpdates: {
+          topic: process.env.KAFKA_ANALYSIS_UPDATES_TOPIC || 'clinical_program_update',
+          group: process.env.KAFKA_ANLYSIS_UPDATES_GROUP || 'file-manager.group.clinical-updates',
+          dlq: process.env.KAFKA_ANALYSIS_UPDATES_DLQ,
         },
       },
       producers: {

--- a/src/external/kafka/clinicalUpdatesConsumer.ts
+++ b/src/external/kafka/clinicalUpdatesConsumer.ts
@@ -1,0 +1,104 @@
+import retry from 'async-retry';
+import { Consumer, Kafka, KafkaMessage, Producer } from 'kafkajs';
+
+import { getAppConfig } from '../../config';
+import { SongAnalysis } from '../song';
+import analysisEventProcessor from '../../jobs/processAnalysisEvent';
+
+import Logger from '../../logger';
+const logger = Logger('Kafka.clinicalUpdatesConsumer');
+
+let clinicalUpdatesConsumer: Consumer | undefined;
+let clinicalUpdatesDlqProducer: Producer | undefined;
+
+export const init = async (kafka: Kafka) => {
+  const consumerConfig = (await getAppConfig()).kafkaProperties.consumers.clinicalUpdates;
+
+  clinicalUpdatesConsumer = kafka.consumer({
+    groupId: consumerConfig.group,
+    retry: {
+      retries: 5,
+      factor: 1.5,
+    },
+  });
+  clinicalUpdatesConsumer.subscribe({
+    topic: consumerConfig.topic,
+  });
+  await clinicalUpdatesConsumer.connect();
+
+  const clinicalDlq = consumerConfig.dlq;
+  if (clinicalDlq) {
+    clinicalUpdatesDlqProducer = kafka.producer({
+      allowAutoTopicCreation: true,
+    });
+    await clinicalUpdatesDlqProducer.connect();
+  }
+
+  await clinicalUpdatesConsumer
+    .run({
+      autoCommit: true,
+      autoCommitThreshold: 10,
+      autoCommitInterval: 10000,
+      eachMessage: async ({ message }) => {
+        logger.info(`New message received offset : ${message.offset}`);
+        await handleAnalysisUpdate(message, clinicalDlq);
+        logger.debug(`Message handled ok`);
+      },
+    })
+    .catch(e => {
+      logger.error('Failed to run consumer.', e);
+      throw e;
+    });
+};
+
+export const disconnect = async () => {
+  await clinicalUpdatesConsumer?.stop();
+  await clinicalUpdatesConsumer?.disconnect();
+  await clinicalUpdatesDlqProducer?.disconnect();
+};
+
+export type AnalysisUpdateEvent = {
+  analysisId: string;
+  studyId: string;
+  state: string; // PUBLISHED, UNPUBLISHED, SUPPRESSED -> maybe more in the future so leaving this as string
+  action: string; // PUBLISH, UNPUBLISH, SUPPRESS, CREATE -> future might add UPDATED
+  songServerId: string;
+  analysis: SongAnalysis;
+};
+
+const sendDlqMessage = async (producer: Producer, dlqTopic: string, messageJSON: string) => {
+  const result = await producer?.send({
+    topic: dlqTopic,
+    messages: [
+      {
+        value: JSON.stringify(messageJSON),
+      },
+    ],
+  });
+  logger.debug(`DLQ message sent to ${dlqTopic}. response: ${JSON.stringify(result)}`);
+};
+
+async function handleAnalysisUpdate(message: KafkaMessage, clinicalDlq?: string) {
+  try {
+    await retry(
+      async (_bail: Function) => {
+        // TODO: validate message body
+        const analysisEvent = JSON.parse(message.value?.toString() || '{}') as AnalysisUpdateEvent;
+        await analysisEventProcessor(analysisEvent);
+      },
+      {
+        retries: 3,
+        factor: 1,
+      },
+    );
+  } catch (err) {
+    logger.error(`Failed to handle analysis message, offset: ${message.offset}`, err);
+    if (clinicalDlq && clinicalUpdatesDlqProducer) {
+      const msg = message.value
+        ? JSON.parse(message.value.toString())
+        : { message: `invalid body, original offset: ${message.offset}` };
+      logger.debug(`Sending message to dlq...`);
+      await sendDlqMessage(clinicalUpdatesDlqProducer, clinicalDlq, msg);
+    }
+  }
+}

--- a/src/external/kafka/clinicalUpdatesConsumer.ts
+++ b/src/external/kafka/clinicalUpdatesConsumer.ts
@@ -2,46 +2,45 @@ import retry from 'async-retry';
 import { Consumer, Kafka, KafkaMessage, Producer } from 'kafkajs';
 
 import { getAppConfig } from '../../config';
-import { SongAnalysis } from '../song';
-import analysisEventProcessor from '../../jobs/processAnalysisEvent';
+import clinicalEventProcessor from '../../jobs/processClinicalEvent';
 
 import Logger from '../../logger';
 const logger = Logger('Kafka.clinicalUpdatesConsumer');
 
-let clinicalUpdatesConsumer: Consumer | undefined;
-let clinicalUpdatesDlqProducer: Producer | undefined;
+let consumer: Consumer | undefined;
+let dlqProducer: Producer | undefined;
 
 export const init = async (kafka: Kafka) => {
   const consumerConfig = (await getAppConfig()).kafkaProperties.consumers.clinicalUpdates;
 
-  clinicalUpdatesConsumer = kafka.consumer({
+  consumer = kafka.consumer({
     groupId: consumerConfig.group,
     retry: {
       retries: 5,
       factor: 1.5,
     },
   });
-  clinicalUpdatesConsumer.subscribe({
+  consumer.subscribe({
     topic: consumerConfig.topic,
   });
-  await clinicalUpdatesConsumer.connect();
+  await consumer.connect();
 
-  const clinicalDlq = consumerConfig.dlq;
-  if (clinicalDlq) {
-    clinicalUpdatesDlqProducer = kafka.producer({
+  const dlq = consumerConfig.dlq;
+  if (dlq) {
+    dlqProducer = kafka.producer({
       allowAutoTopicCreation: true,
     });
-    await clinicalUpdatesDlqProducer.connect();
+    await dlqProducer.connect();
   }
 
-  await clinicalUpdatesConsumer
+  await consumer
     .run({
       autoCommit: true,
       autoCommitThreshold: 10,
       autoCommitInterval: 10000,
       eachMessage: async ({ message }) => {
         logger.info(`New message received offset : ${message.offset}`);
-        await handleAnalysisUpdate(message, clinicalDlq);
+        await handleMessage(message, dlq);
         logger.debug(`Message handled ok`);
       },
     })
@@ -52,18 +51,14 @@ export const init = async (kafka: Kafka) => {
 };
 
 export const disconnect = async () => {
-  await clinicalUpdatesConsumer?.stop();
-  await clinicalUpdatesConsumer?.disconnect();
-  await clinicalUpdatesDlqProducer?.disconnect();
+  await consumer?.stop();
+  await consumer?.disconnect();
+  await dlqProducer?.disconnect();
 };
 
-export type AnalysisUpdateEvent = {
-  analysisId: string;
-  studyId: string;
-  state: string; // PUBLISHED, UNPUBLISHED, SUPPRESSED -> maybe more in the future so leaving this as string
-  action: string; // PUBLISH, UNPUBLISH, SUPPRESS, CREATE -> future might add UPDATED
-  songServerId: string;
-  analysis: SongAnalysis;
+export type ClinicalUpdateEvent = {
+  programId: string;
+  donorIds?: string[];
 };
 
 const sendDlqMessage = async (producer: Producer, dlqTopic: string, messageJSON: string) => {
@@ -78,13 +73,14 @@ const sendDlqMessage = async (producer: Producer, dlqTopic: string, messageJSON:
   logger.debug(`DLQ message sent to ${dlqTopic}. response: ${JSON.stringify(result)}`);
 };
 
-async function handleAnalysisUpdate(message: KafkaMessage, clinicalDlq?: string) {
+async function handleMessage(message: KafkaMessage, clinicalDlq?: string) {
   try {
     await retry(
       async (_bail: Function) => {
         // TODO: validate message body
-        const analysisEvent = JSON.parse(message.value?.toString() || '{}') as AnalysisUpdateEvent;
-        await analysisEventProcessor(analysisEvent);
+        const clinicalEvent = JSON.parse(message.value?.toString() || '{}') as ClinicalUpdateEvent;
+        // TODO: Message handling goes here
+        await clinicalEventProcessor(clinicalEvent);
       },
       {
         retries: 3,
@@ -93,12 +89,12 @@ async function handleAnalysisUpdate(message: KafkaMessage, clinicalDlq?: string)
     );
   } catch (err) {
     logger.error(`Failed to handle analysis message, offset: ${message.offset}`, err);
-    if (clinicalDlq && clinicalUpdatesDlqProducer) {
+    if (clinicalDlq && dlqProducer) {
       const msg = message.value
         ? JSON.parse(message.value.toString())
         : { message: `invalid body, original offset: ${message.offset}` };
       logger.debug(`Sending message to dlq...`);
-      await sendDlqMessage(clinicalUpdatesDlqProducer, clinicalDlq, msg);
+      await sendDlqMessage(dlqProducer, clinicalDlq, msg);
     }
   }
 }

--- a/src/external/kafka/index.ts
+++ b/src/external/kafka/index.ts
@@ -20,6 +20,7 @@
 import { Kafka } from 'kafkajs';
 import { AppConfig } from '../../config';
 import * as analysisUpdatesConsumer from './analysisUpdatesConsumer';
+import * as clinicalUpdatesConsumer from './analysisUpdatesConsumer';
 import * as recalculateEmbargoConsumer from './recalculateEmbargoConsumer';
 import * as publicReleaseProducer from './publicReleaseProducer';
 import Logger from '../../logger';
@@ -37,6 +38,12 @@ export const setup = async (config: AppConfig): Promise<void> => {
     recalculateEmbargoConsumer.init(kafka),
     publicReleaseProducer.init(kafka),
   ]);
+
+  if (config.features.clinicalDataIndexing) {
+    // Init the clinical updates consumer if clinical data indexing is enabled
+    await clinicalUpdatesConsumer.init(kafka);
+  }
+
   logger.info('Connected.');
 };
 
@@ -44,6 +51,7 @@ export const disconnect = async () => {
   logger.warn('Disconnecting all from Kafka...');
   await Promise.all([
     analysisUpdatesConsumer.disconnect(),
+    clinicalUpdatesConsumer.disconnect(), // safe to disconnect even if not initialized
     recalculateEmbargoConsumer.disconnect(),
     publicReleaseProducer.disconnect(),
   ]);

--- a/src/external/kafka/recalculateEmbargoConsumer.ts
+++ b/src/external/kafka/recalculateEmbargoConsumer.ts
@@ -7,24 +7,24 @@ import recalculateFileEmbargo from '../../jobs/recalculateFileEmbargo';
 import Logger from '../../logger';
 const logger = Logger('Kafka.recalculateEmbargoConsumer');
 
-let recalculateEmbargoConsumer: Consumer | undefined;
+let consumer: Consumer | undefined;
 
 export const init = async (kafka: Kafka) => {
   const consumerConfig = (await getAppConfig()).kafkaProperties.consumers.recalculateEmbargo;
 
-  recalculateEmbargoConsumer = kafka.consumer({
+  consumer = kafka.consumer({
     groupId: consumerConfig.group,
     retry: {
       retries: 5,
       factor: 1.5,
     },
   });
-  recalculateEmbargoConsumer.subscribe({
+  consumer.subscribe({
     topic: consumerConfig.topic,
   });
-  await recalculateEmbargoConsumer.connect();
+  await consumer.connect();
 
-  recalculateEmbargoConsumer
+  consumer
     .run({
       autoCommit: true,
       autoCommitThreshold: 10,
@@ -42,8 +42,8 @@ export const init = async (kafka: Kafka) => {
 };
 
 export const disconnect = async () => {
-  await recalculateEmbargoConsumer?.stop();
-  await recalculateEmbargoConsumer?.disconnect();
+  await consumer?.stop();
+  await consumer?.disconnect();
 };
 
 async function handleMessage() {

--- a/src/jobs/processAnalysisEvent.ts
+++ b/src/jobs/processAnalysisEvent.ts
@@ -17,7 +17,6 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import Logger from '../logger';
 import { convertAnalysesToFileDocuments } from '../external/analysisConverter';
 import { AnalysisUpdateEvent } from '../external/kafka/analysisUpdatesConsumer';
 import { saveAndIndexFilesFromRdpcData } from '../services/fileManager';
@@ -25,6 +24,8 @@ import { isRestricted } from '../services/utils/fileUtils';
 import { getIndexer } from '../services/indexer';
 import * as fileService from '../data/files';
 import PromisePool from '@supercharge/promise-pool';
+
+import Logger from '../logger';
 const logger = Logger('Job:ProcessAnalysisEvent');
 
 async function handleSongPublishedAnalysis(analysis: any, dataCenterId: string) {

--- a/src/jobs/processClinicalEvent.ts
+++ b/src/jobs/processClinicalEvent.ts
@@ -1,0 +1,28 @@
+import { ClinicalUpdateEvent } from '../external/kafka/clinicalUpdatesConsumer';
+import { getAppConfig } from '../config';
+
+import Logger from '../logger';
+const logger = Logger('Job:ProcessClinicalEvent');
+
+/**
+ * Clinical Data Update Event Processor
+ * @param clinicalEvent
+ */
+const clinicalUpdateEvent = async (clinicalEvent: ClinicalUpdateEvent) => {
+  const { programId, donorIds } = clinicalEvent;
+  const config = await getAppConfig();
+  if (config.features.clinicalDataIndexing) {
+    logger.info(
+      `START - processing clinical data update event for program ${programId} including ${donorIds?.length ||
+        0} donors`,
+    );
+
+    logger.info(`DONE - processing clinical data update event for program ${programId}`);
+  } else {
+    logger.info(
+      `DISABLED - no processing performed for clinical update event. Event is for program ${programId} including ${donorIds?.length ||
+        0} donors`,
+    );
+  }
+};
+export default clinicalUpdateEvent;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,8 @@
     "experimentalDecorators": true,
     "sourceMap": true,
     "outDir": "dist",
-    "baseUrl": ".",
     "paths": {
-      "*": ["node_modules/*", "src/types/*"]
+      "*": ["./node_modules/*", "./src/types/*"]
     }
   },
   "exclude": ["node_modules"],


### PR DESCRIPTION
Adds consumer for clinical update event `clinical_program_update`.

Currently just triggers the same functionality as analysis update event.