### PR TITLE
File Data Model supports Clinical Data Exemptions to Embargo Rules

### DIFF
--- a/src/data/files/file.model.ts
+++ b/src/data/files/file.model.ts
@@ -45,7 +45,7 @@ export enum EmbargoStage {
  * - ADMIN: DCC Admin has made the decision to make this file publicly available without requiring clinical data.
  */
 export enum ClinicalExemption {
-  LEGACY = 'LEGACY_DATA',
+  LEGACY = 'LEGACY',
   EARLY_RELEASE = 'EARLY_RELEASE',
   ADMIN = 'ADMIN',
 }

--- a/src/data/files/file.model.ts
+++ b/src/data/files/file.model.ts
@@ -37,6 +37,19 @@ export enum EmbargoStage {
   PUBLIC = 'PUBLIC',
 }
 
+/**
+ * A file with a clinical exemption can be released to the file index even if it fails to pass the clinical data requirements.
+ * The enum values indicate the reason the file was given the exemption:
+ * - LEGACY: This file was publicly available in the Legacy ICGC system so does not need to pass through the embargo stages.
+ * - EARLY_RELEASE: This file was published publicly in ARGO before the clinical embargo requirements were enforced.
+ * - ADMIN: DCC Admin has made the decision to make this file publicly available without requiring clinical data.
+ */
+export enum ClinicalExemption {
+  LEGACY = 'LEGACY_DATA',
+  EARLY_RELEASE = 'EARLY_RELEASE',
+  ADMIN = 'ADMIN',
+}
+
 export enum FileReleaseState {
   RESTRICTED = 'RESTRICTED',
   QUEUED_TO_PUBLIC = 'QUEUED',
@@ -78,6 +91,8 @@ interface DbFile {
   adminPromote?: string;
   adminDemote?: string;
 
+  clinicalExemption?: string;
+
   labels: FileLabel[];
 }
 
@@ -101,19 +116,9 @@ export interface File {
   adminPromote?: EmbargoStage;
   adminDemote?: EmbargoStage;
 
-  labels: FileLabel[];
-}
+  clinicalExemption?: ClinicalExemption;
 
-export interface FilesResponse {
-  files: File[];
-  meta: {
-    totalFiles: number;
-    pageSize: number;
-    totalPages: number;
-    hasPrevPage: boolean;
-    hasNextPage: boolean;
-    currentPage?: number;
-  };
+  labels: FileLabel[];
 }
 
 // FileInput matches the File object, but with optional fields where
@@ -176,6 +181,8 @@ const FileSchema = new mongoose.Schema(
       enum: Object.values(EmbargoStage),
     },
     adminHold: { type: Boolean, required: false },
+
+    clinicalExemption: { type: String, required: false, enum: Object.values(ClinicalExemption) },
 
     labels: [LabelSchema],
   },

--- a/src/data/files/index.ts
+++ b/src/data/files/index.ts
@@ -15,6 +15,7 @@ export {
   addOrUpdateFileLabel,
   adminPromote,
   adminDemote,
+  applyClinicalExemption,
   countFiles,
   deleteByIds,
   getFiles,
@@ -31,4 +32,5 @@ export {
   updateFileAdminControls,
   updateFileSongPublishStatus,
   removeLabel,
+  removeClinicalExemption,
 } from './file.service';

--- a/src/resources/swagger.yaml
+++ b/src/resources/swagger.yaml
@@ -652,7 +652,7 @@ components:
           type: string
     ClinicalExemption:
       type: string
-      enum: [LEGACY_DATA, EARLY_RELEASE, ADMIN]
+      enum: [LEGACY, EARLY_RELEASE, ADMIN]
     EmbargoStage:
       type: string
       enum: [PROGRAM_ONLY, MEMBER_ACCESS, ASSOCIATE_ACCESS, PUBLIC]

--- a/src/resources/swagger.yaml
+++ b/src/resources/swagger.yaml
@@ -494,6 +494,70 @@ paths:
                 $ref: '#components/schemas/SelectedFilesResponse'
         '400':
           description: No files updated, maybe the filter is too strict.
+  /admin/clinicalExemption/{reason}:
+    post:
+      tags:
+        - Admin
+      description: Mark the selected files as being exempt from the core clinical data requirement for being released into the file index.
+      parameters:
+        - name: reason
+          description: The reason the file is exempt form the core clinical data requirements
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/ClinicalExemption'
+        - name: dryRun
+          description: Set to "true" to test the provided file filter selection. No data changed if true.
+          in: query
+          required: false
+          schema:
+            type: boolean
+
+      requestBody:
+        description: Filters to apply to select files for promotion
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FileFilter'
+
+      responses:
+        '200':
+          description: Files updated, then re-indexed as required.
+          content:
+            application/json:
+              schema:
+                $ref: '#components/schemas/SelectedFilesResponse'
+        '400':
+          description: No files updated, maybe the filter is too strict.
+  /admin/clinicalExemption/remove:
+    post:
+      tags:
+        - Admin
+      description: Remove the clinical exemption from the selected files.
+      parameters:
+        - name: dryRun
+          description: Set to "true" to test the provided file filter selection. No data changed if true.
+          in: query
+          required: false
+          schema:
+            type: boolean
+
+      requestBody:
+        description: Filters to apply to select files for promotion
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FileFilter'
+
+      responses:
+        '200':
+          description: Files updated, then re-indexed as required.
+          content:
+            application/json:
+              schema:
+                $ref: '#components/schemas/SelectedFilesResponse'
+        '400':
+          description: No files updated, maybe the filter is too strict.
 
   /debug/handleAnalysisEvent:
     post:
@@ -586,6 +650,9 @@ components:
           type: string
         analysisId:
           type: string
+    ClinicalExemption:
+      type: string
+      enum: [LEGACY_DATA, EARLY_RELEASE, ADMIN]
     EmbargoStage:
       type: string
       enum: [PROGRAM_ONLY, MEMBER_ACCESS, ASSOCIATE_ACCESS, PUBLIC]

--- a/src/routers/common/validator.ts
+++ b/src/routers/common/validator.ts
@@ -2,6 +2,7 @@ import Ajv, { JSONSchemaType, ErrorObject, DefinedError } from 'ajv';
 
 import { fileFilterSchema } from './FileFilter';
 import { EmbargoStage } from '../../data/files';
+import { ClinicalExemption } from '../../data/files/file.model';
 
 const ajv = new Ajv();
 
@@ -26,7 +27,15 @@ const embargoStageValidator = (value: any): EmbargoStage => {
   return value as EmbargoStage;
 };
 
+const clinicalExemptionValidator = (value: any): ClinicalExemption => {
+  if (!Object.values(ClinicalExemption).includes(value)) {
+    throw new Error(JSON.stringify({ message: `Invalid clinical exemption reason: ${value}` }));
+  }
+  return value as ClinicalExemption;
+};
+
 const validator = {
+  clinicalExemption: clinicalExemptionValidator,
   embargoStage: embargoStageValidator,
   fileFilter: createParamValidator(fileFilterSchema),
 };


### PR DESCRIPTION
`clinicalExemption` was added as a property to the file data model. This property will be used to determine if the clinical core completion rules apply when calculating embargo stages for each file. These changes to calculating embargo stage are not part of this PR.

The value of the `clinicalExemption` property is an enum that includes the different reasons possible for applying a clinical exemption:
 > - LEGACY_DATA: This file was publicly available in the Legacy ICGC system so does not need to pass through the embargo stages.
>  - EARLY_RELEASE: This file was published publicly in ARGO before the clinical embargo requirements were enforced.
>  - ADMIN: DCC Admin has made the decision to make this file publicly available without requiring clinical data.

Two admin endpoints were added to the API to allow an admin user to apply or remove these exemptions to a selection of files.