### PR TITLE
Check donor data is valid to start embargo

### DIFF
--- a/src/services/embargo.ts
+++ b/src/services/embargo.ts
@@ -165,15 +165,26 @@ export function calculateEmbargoStartDate(inputs: {
 }): Date | undefined {
   const { dbFile, songAnalysis, matchedSamplePairs, clinicalDonor } = inputs;
 
-  // Check for clinical exemption and ensure required data is provided.
+  // Check for clinical exemption, if no exemption then we need valid clinical data
   const clinicalExemption: boolean = dbFile.clinicalExemption !== undefined;
-  if (!clinicalExemption && !clinicalDonor) {
-    logger.info(
-      `calculateEmbargoStartDate()`,
-      dbFile.fileId,
-      `file ${dbFile.fileId} does not have a clinical exemption and has no clinical donor data provided.`,
-    );
-    return undefined;
+  const validClinicalData: boolean = clinicalDonor?.schemaMetadata?.isValid || false;
+  if (!clinicalExemption) {
+    if (!clinicalDonor) {
+      logger.info(
+        `calculateEmbargoStartDate()`,
+        dbFile.fileId,
+        `file ${dbFile.fileId} has no clinical donor data available and has no clinical exemption.`,
+      );
+      return undefined;
+    }
+    if (!validClinicalData) {
+      logger.info(
+        `calculateEmbargoStartDate()`,
+        dbFile.fileId,
+        `file ${dbFile.fileId} has a donor with invalid clinical data and has no clinical exemption.`,
+      );
+      return undefined;
+    }
   }
 
   // 1. First Published date of this file's song analysis


### PR DESCRIPTION
When calculating embargo start date, check that the donor data provided is valid. If it is not, do not start embargo.

If there is a clinical exemption, we do not need to consider clinical data so this check does not apply when there is a clinical exemption.