### PR TITLE
Files include property indicating when they have complete clinical data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,7 +85,7 @@ CREATE_SAMPLE_INDEX=false
 ############
 #  Maestro #
 ############
-ANALYSIS_CONVERTER_URL=https://maestro.dev.argo.cancercollaboratory.org/convert
+ANALYSIS_CONVERTER_URL=https://localhost:11235/convert
 ANALYSIS_CONVERTER_TIMEOUT=30000
 
 ###############

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -23,9 +23,9 @@ services:
     container_name: files_db
     image: 'bitnami/mongodb:4.0'
     ports:
-      - '27027:27017'
+      - 27027:27017
     volumes:
-      - 'mongodb_data:/bitnami'
+      - mongodb_data:/bitnami
     environment:
       MONGODB_USERNAME: admin
       MONGODB_PASSWORD: password
@@ -37,7 +37,7 @@ services:
   ################################
   elasticsearch:
     container_name: files_es
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.10
     ports:
       - 9200:9200
     volumes:
@@ -50,7 +50,7 @@ services:
 
   kibana:
     container_name: files_kibana
-    image: docker.elastic.co/kibana/kibana:7.10.2
+    image: docker.elastic.co/kibana/kibana:7.17.10
     depends_on:
       - elasticsearch
     ports:
@@ -62,7 +62,7 @@ services:
     depends_on:
       - elasticsearch
     ports:
-      - '9001:9001'
+      - 9001:9001
     environment:
       ELASTICSEARCH_NODE: http://elasticsearch:9200
       SPRING_PROFILES_ACTIVE: test
@@ -72,6 +72,28 @@ services:
       ROLLCALL_ALIASES_0_TYPE: centric
       ROLLCALL_ALIASES_0_RELEASEROTATION: 2
       SPRING_CLOUD_VAULT_ENABLED: 'false'
+
+  maestro:
+    container_name: files_maestro
+    image: overture/maestro:4.0.0
+    depends_on:
+      - elasticsearch
+    ports:
+      - 11235:11235
+    environment:
+      MAESTRO_ELASTICSEARCH_CLIENT_BASICAUTH_ENABLED: false
+      MAESTRO_ELASTICSEARCH_CLIENT_BASICAUTH_USER: elastic
+      MAESTRO_ELASTICSEARCH_CLIENT_BASICAUTH_PASSWORD: not_used
+      MAESTRO_ELASTICSEARCH_CLUSTERNODES_0: http://localhost:9200
+      MAESTRO_ELASTICSEARCH_INDEXES_ANALYSISCENTRIC_ENABLED: false
+      MAESTRO_NOTIFICATIONS_SLACK_ENABLED: false
+      MAESTRO_REPOSITORIES_0_CODE: local.example
+      MAESTRO_REPOSITORIES_0_COUNTRY: CA
+      MAESTRO_REPOSITORIES_0_DATAPATH:
+      MAESTRO_REPOSITORIES_0_METADATAPATH:
+      MAESTRO_REPOSITORIES_0_NAME: Local Dev Example
+      MAESTRO_REPOSITORIES_0_ORGANIZATION: rdpc-collab
+      MAESTRO_REPOSITORIES_0_URL: https://localhost:8081
 
   ################################
   ####    KAFKA containers    ####
@@ -89,8 +111,8 @@ services:
     depends_on:
       - zookeeper
     ports:
-      - '29092:29092'
-      - '9092:9092'
+      - 29092:29092
+      - 9092:9092
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
@@ -126,7 +148,7 @@ services:
       - zookeeper
       - broker
     ports:
-      - '9021:9021'
+      - 9021:9021
     environment:
       CONTROL_CENTER_BOOTSTRAP_SERVERS: 'broker:29092'
       CONTROL_CENTER_ZOOKEEPER_CONNECT: 'zookeeper:2181'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "files-service",
-  "version": "0.24.0",
+  "version": "0.28.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "files-service",
-      "version": "0.23.0",
+      "version": "0.28.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@elastic/elasticsearch": "7.5.0",
@@ -49,7 +49,8 @@
         "ts-node": "^8.5.4",
         "url-join": "^4.0.1",
         "winston": "^3.2.1",
-        "yamljs": "^0.3.0"
+        "yamljs": "^0.3.0",
+        "zod": "^3.22.2"
       },
       "devDependencies": {
         "@types/async-retry": "^1.4.2",
@@ -102,7 +103,7 @@
         "sinon": "^7.3.2",
         "testcontainers": "^6.4.0",
         "tslint": "^5.20.1",
-        "typescript": "^4.0.2"
+        "typescript": "^4.9.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2006,15 +2007,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/copyfiles/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
     },
     "node_modules/copyfiles/node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -4864,26 +4856,6 @@
         "url": "https://opencollective.com/mochajs"
       }
     },
-    "node_modules/mocha/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/mocha/node_modules/cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      }
-    },
     "node_modules/mocha/node_modules/debug": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -4901,12 +4873,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/mocha/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
     },
     "node_modules/mocha/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -4936,15 +4902,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mocha/node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/mocha/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4952,15 +4909,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/mocha/node_modules/js-yaml": {
@@ -5036,38 +4984,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/mocha/node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
-    "node_modules/mocha/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/mocha/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5093,109 +5009,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/mocha/node_modules/wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/mock-http-server": {
@@ -8175,9 +7988,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8920,6 +8733,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
+      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   },
@@ -10552,12 +10373,6 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
         },
         "wrap-ansi": {
@@ -12832,23 +12647,6 @@
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
         "debug": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -12857,12 +12655,6 @@
           "requires": {
             "ms": "2.1.2"
           }
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
         },
         "escape-string-regexp": {
           "version": "4.0.0",
@@ -12880,22 +12672,10 @@
             "path-exists": "^4.0.0"
           }
         },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-          "dev": true
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "js-yaml": {
@@ -12947,32 +12727,6 @@
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
         },
-        "require-main-filename": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12989,90 +12743,6 @@
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          }
-        },
-        "yargs": {
-          "version": "13.3.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.2"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-              "dev": true,
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-              "dev": true,
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-              "dev": true,
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-              "dev": true,
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "path-exists": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-              "dev": true
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "13.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
           }
         }
       }
@@ -15451,9 +15121,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg=="
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "uid-safe": {
       "version": "2.1.5",
@@ -16045,6 +15715,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
+      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "sinon": "^7.3.2",
     "testcontainers": "^6.4.0",
     "tslint": "^5.20.1",
-    "typescript": "^4.0.2"
+    "typescript": "^4.9.0"
   },
   "dependencies": {
     "@elastic/elasticsearch": "7.5.0",
@@ -119,7 +119,8 @@
     "ts-node": "^8.5.4",
     "url-join": "^4.0.1",
     "winston": "^3.2.1",
-    "yamljs": "^0.3.0"
+    "yamljs": "^0.3.0",
+    "zod": "^3.22.2"
   },
   "husky": {
     "hooks": {

--- a/src/data/files/file.service.ts
+++ b/src/data/files/file.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
  *
  * This program and the accompanying materials are made available under the terms of
  * the GNU Affero General Public License v3.0. You should have received a copy of the
@@ -142,6 +142,10 @@ export async function updateFileAdminControls(objectId: string, updates: AdminCo
 type FileSongPublishStatus = { status?: string; firstPublished?: Date };
 export async function updateFileSongPublishStatus(objectId: string, updates: FileSongPublishStatus): Promise<File> {
   return toPojo(await fileModel.updateByObjectId(objectId, updates, { new: true }));
+}
+
+export async function updateFileHasClinicalData(objectId: string, hasClinicalData: boolean): Promise<File> {
+  return toPojo(await fileModel.updateByObjectId(objectId, { hasClinicalData: true }, { new: true }));
 }
 
 export async function applyClinicalExemption(

--- a/src/data/files/index.ts
+++ b/src/data/files/index.ts
@@ -31,6 +31,7 @@ export {
   updateFileReleaseProperties,
   updateFileAdminControls,
   updateFileSongPublishStatus,
+  updateFileHasClinicalData,
   removeLabel,
   removeClinicalExemption,
 } from './file.service';

--- a/src/data/releases/release.model.ts
+++ b/src/data/releases/release.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
  *
  * This program and the accompanying materials are made available under the terms of
  * the GNU Affero General Public License v3.0. You should have received a copy of the
@@ -101,7 +101,7 @@ const ReleaseSchema = new mongoose.Schema(
     indices: { type: [String], required: true, default: [] },
     snapshot: { type: String, required: false },
   },
-  { timestamps: true, minimize: false, optimisticConcurrency: true } as any, // optimistic concurrency is not defined in the types yet
+  { timestamps: true, minimize: false, optimisticConcurrency: true }, // optimistic concurrency is not defined in the types yet
 );
 
 export type ReleaseMongooseDocument = mongoose.Document & DbRelease;
@@ -160,7 +160,7 @@ export async function getLatestRelease(): Promise<ReleaseMongooseDocument | unde
 }
 
 export async function getReleases(): Promise<ReleaseMongooseDocument[]> {
-  return (await ReleaseModel.find({}).exec()) as ReleaseMongooseDocument[];
+  return await ReleaseModel.find({}).exec();
 }
 
 /**

--- a/src/external/clinical/types.ts
+++ b/src/external/clinical/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
  *
  * This program and the accompanying materials are made available under the terms of
  * the GNU Affero General Public License v3.0. You should have received a copy of the
@@ -17,101 +17,106 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import { z as zod } from 'zod';
+
+//  Record<string, string | number | boolean | undefined>;
+export const ClinicalInfo = zod.record(zod.union([zod.string(), zod.number(), zod.boolean()]).optional());
+
+export const ClinicalSample = zod.object({
+  clinicalInfo: ClinicalInfo,
+  sampleId: zod.string(),
+  submitterId: zod.string(),
+  sampleType: zod.string(),
+});
+export const ClinicalSpecimen = zod.object({
+  clinicalInfo: ClinicalInfo,
+  samples: zod.array(ClinicalSample),
+  specimenId: zod.string(),
+  submitterId: zod.string(),
+  tumourNormalDesignation: zod.string(),
+  specimenType: zod.string(),
+  specimenTissueSource: zod.string(),
+});
+// TODO: The properties we want to index from the following types should be declared.
+export const ClinicalFollowUp = zod.object({
+  clinicalInfo: ClinicalInfo,
+  followUpId: zod.string(),
+});
+export const ClinicalPrimaryDiagnosis = zod.object({
+  clinicalInfo: ClinicalInfo,
+  primaryDiagnosisId: zod.string(),
+});
+export const ClinicalTherapy = zod.object({
+  clinicalInfo: ClinicalInfo,
+  therapyId: zod.string(),
+});
+export const ClinicalTreatment = zod.object({
+  clinicalInfo: ClinicalInfo,
+  therapies: zod.array(ClinicalTherapy),
+  treatmentId: zod.string(),
+});
+export const ClinicalFamilyHistory = zod.object({
+  clinicalInfo: ClinicalInfo,
+  familyHistoryId: zod.string(),
+});
+export const ClinicalExposure = zod.object({
+  clinicalInfo: ClinicalInfo,
+  exposureId: zod.string(),
+});
+export const ClinicalComorbidity = zod.object({
+  clinicalInfo: ClinicalInfo,
+  comorbidityId: zod.string(),
+});
+export const ClinicalBiomarker = zod.object({
+  clinicalInfo: ClinicalInfo,
+  biomarkerId: zod.string(),
+});
+
 /**
  * The specific content in ClinicalDonor type is subject to change as the data-dictionary is updated,
  * so we try to only define here the bare minimum of fields that are needed to interact with and index the clinical data.
+ * For this reason, the Zod schema must allow additional properties to be present (not strict).
  *
  * Note: we receive all dates as strings. The type declaration here has them listed as strings, but if it makes sense in the future
- * we can parse them into proper Date objects when the `JSON.parse(donor)` is called.
+ * we can update the Zod schema to parse them into dates.
  */
-export type ClinicalDonor = {
-  donorId: string;
-  gender: string;
-  programId: string;
+export const ClinicalDonor = zod.object({
+  donorId: zod.string(),
+  gender: zod.string(),
+  programId: zod.string(),
 
-  submitterId: string;
-  createdAt: string;
-  updatedAt: string;
-  schemaMetadata: {
-    isValid: boolean;
-    lastValidSchemaVersion: string;
-    originalSchemaVersion: string;
-    lastMigrationId: string;
-  };
-  completionStats: {
-    coreCompletion: {
-      donor: number;
-      specimens: number;
-      primaryDiagnosis: number;
-      followUps: number;
-      treatments: number;
-    };
-    overriddenCoreCompletion: string[];
-    coreCompletionPercentage: number;
-    coreCompletionDate: string;
-  };
+  submitterId: zod.string(),
+  createdAt: zod.string(),
+  updatedAt: zod.string(),
+  schemaMetadata: zod.object({
+    isValid: zod.boolean(),
+    lastValidSchemaVersion: zod.string(),
+    originalSchemaVersion: zod.string(),
+    lastMigrationId: zod.string(),
+  }),
+  completionStats: zod.object({
+    coreCompletion: zod.object({
+      donor: zod.number(),
+      specimens: zod.number(),
+      primaryDiagnosis: zod.number(),
+      followUps: zod.number(),
+      treatments: zod.number(),
+    }),
+    overriddenCoreCompletion: zod.array(zod.string()),
+    coreCompletionPercentage: zod.number(),
+    coreCompletionDate: zod.string(),
+  }),
 
   // core
-  specimens: ClinicalSpecimen[];
-  followUps: ClinicalFollowUp[];
-  primaryDiagnoses: ClinicalPrimaryDiagnosis[];
-  treatments: ClinicalTreatment[];
+  specimens: zod.array(ClinicalSpecimen),
+  followUps: zod.array(ClinicalFollowUp),
+  primaryDiagnoses: zod.array(ClinicalPrimaryDiagnosis),
+  treatments: zod.array(ClinicalTreatment),
 
   // expanded
-  familyHistory: ClinicalFamilyHistory[];
-  exposure: ClinicalExposure[];
-  comorbidity: ClinicalComorbidity[];
-  biomarker: ClinicalBiomarker[];
-};
-
-export type ClinicalInfo = Record<string, string | number | boolean | undefined>;
-
-export type ClinicalSpecimen = {
-  clinicalInfo: ClinicalInfo;
-  samples: ClinicalSample[];
-  specimenId: string;
-  submitterId: string;
-  tumourNormalDesignation: string;
-  specimenType: string;
-  specimenTissueSource: string;
-};
-export type ClinicalSample = {
-  clinicalInfo: ClinicalInfo;
-  sampleId: string;
-  submitterId: string;
-  sampleType: string;
-};
-// TODO: The properties we want to index from the following types should be declared.
-export type ClinicalFollowUp = {
-  clinicalInfo: ClinicalInfo;
-  followUpId: string;
-};
-export type ClinicalPrimaryDiagnosis = {
-  clinicalInfo: ClinicalInfo;
-  primaryDiagnosisId: string;
-};
-export type ClinicalTreatment = {
-  clinicalInfo: ClinicalInfo;
-  therapies: ClinicalTherapy[];
-  treatmentId: string;
-};
-export type ClinicalTherapy = {
-  clinicalInfo: ClinicalInfo;
-  therapyId: string;
-};
-export type ClinicalFamilyHistory = {
-  clinicalInfo: ClinicalInfo;
-  familyHistoryId: string;
-};
-export type ClinicalExposure = {
-  clinicalInfo: ClinicalInfo;
-  exposureId: string;
-};
-export type ClinicalComorbidity = {
-  clinicalInfo: ClinicalInfo;
-  comorbidityId: string;
-};
-export type ClinicalBiomarker = {
-  clinicalInfo: ClinicalInfo;
-  biomarkerId: string;
-};
+  familyHistory: zod.array(ClinicalFamilyHistory),
+  exposure: zod.array(ClinicalExposure),
+  comorbidity: zod.array(ClinicalComorbidity),
+  biomarker: zod.array(ClinicalBiomarker),
+});
+export type ClinicalDonor = zod.infer<typeof ClinicalDonor>;

--- a/src/external/clinical/types.ts
+++ b/src/external/clinical/types.ts
@@ -33,49 +33,12 @@ export const ClinicalSpecimen = zod.object({
   samples: zod.array(ClinicalSample),
   specimenId: zod.string(),
   submitterId: zod.string(),
-  tumourNormalDesignation: zod.string(),
-  specimenType: zod.string(),
-  specimenTissueSource: zod.string(),
-});
-// TODO: The properties we want to index from the following types should be declared.
-export const ClinicalFollowUp = zod.object({
-  clinicalInfo: ClinicalInfo,
-  followUpId: zod.string(),
-});
-export const ClinicalPrimaryDiagnosis = zod.object({
-  clinicalInfo: ClinicalInfo,
-  primaryDiagnosisId: zod.string(),
-});
-export const ClinicalTherapy = zod.object({
-  clinicalInfo: ClinicalInfo,
-  therapyId: zod.string(),
-});
-export const ClinicalTreatment = zod.object({
-  clinicalInfo: ClinicalInfo,
-  therapies: zod.array(ClinicalTherapy),
-  treatmentId: zod.string(),
-});
-export const ClinicalFamilyHistory = zod.object({
-  clinicalInfo: ClinicalInfo,
-  familyHistoryId: zod.string(),
-});
-export const ClinicalExposure = zod.object({
-  clinicalInfo: ClinicalInfo,
-  exposureId: zod.string(),
-});
-export const ClinicalComorbidity = zod.object({
-  clinicalInfo: ClinicalInfo,
-  comorbidityId: zod.string(),
-});
-export const ClinicalBiomarker = zod.object({
-  clinicalInfo: ClinicalInfo,
-  biomarkerId: zod.string(),
 });
 
 /**
- * The specific content in ClinicalDonor type is subject to change as the data-dictionary is updated,
- * so we try to only define here the bare minimum of fields that are needed to interact with and index the clinical data.
- * For this reason, the Zod schema must allow additional properties to be present (not strict).
+ * This object is an partial representation of the data returned from the clinical donor api. We are only validating the fields that
+ * are relevant to the file service's usage. When additional information from the clinical API is needed those fields should be added
+ * to this schema definition.
  *
  * Note: we receive all dates as strings. The type declaration here has them listed as strings, but if it makes sense in the future
  * we can update the Zod schema to parse them into dates.
@@ -106,17 +69,5 @@ export const ClinicalDonor = zod.object({
     coreCompletionPercentage: zod.number(),
     coreCompletionDate: zod.string(),
   }),
-
-  // core
-  specimens: zod.array(ClinicalSpecimen),
-  followUps: zod.array(ClinicalFollowUp),
-  primaryDiagnoses: zod.array(ClinicalPrimaryDiagnosis),
-  treatments: zod.array(ClinicalTreatment),
-
-  // expanded
-  familyHistory: zod.array(ClinicalFamilyHistory),
-  exposure: zod.array(ClinicalExposure),
-  comorbidity: zod.array(ClinicalComorbidity),
-  biomarker: zod.array(ClinicalBiomarker),
 });
 export type ClinicalDonor = zod.infer<typeof ClinicalDonor>;

--- a/src/external/dataCenterGateway/index.ts
+++ b/src/external/dataCenterGateway/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
  *
  * This program and the accompanying materials are made available under the terms of
  * the GNU Affero General Public License v3.0. You should have received a copy of the
@@ -27,7 +27,7 @@ import { getEgoToken } from '../../external/ego';
 import Logger from '../../logger';
 const logger = Logger('DataCenterGateway');
 
-export const getAlignmentMetrics = async (runId: String) => {
+export const getAlignmentMetrics = async (runId: string) => {
   const config = await getAppConfig();
   const url = config.datacenter.gatewayUrl;
   const graphQLClient = new GraphQLClient(url, {

--- a/src/external/rollcall.ts
+++ b/src/external/rollcall.ts
@@ -164,7 +164,10 @@ export default async (): Promise<RollCallClient> => {
       headers: { 'Content-Type': 'application/json' },
     })
       .then(_ => true)
-      .catch(_ => false);
+      .catch(err => {
+        logger.warn(`release()`, `Error returned from release index request`, resovledIndex.indexName, err);
+        return false;
+      });
   };
 
   const configureIndex = async (index: Index): Promise<void> => {

--- a/src/external/rollcall.ts
+++ b/src/external/rollcall.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
  *
  * This program and the accompanying materials are made available under the terms of
  * the GNU Affero General Public License v3.0. You should have received a copy of the
@@ -93,21 +93,18 @@ export default async (): Promise<RollCallClient> => {
   const aliasName = config.rollcall.aliasName;
   const indexEntity = config.rollcall.entity;
   const indexType = 'centric';
-  const shardPrefix = (isPublic: boolean) =>
-    isPublic ? RELEASE_STATE.PUBLIC : RELEASE_STATE.RESTRICTED;
+  const shardPrefix = (isPublic: boolean) => (isPublic ? RELEASE_STATE.PUBLIC : RELEASE_STATE.RESTRICTED);
   const releasePrefix = 're';
 
   const client = await getClient();
 
-  const fetchCurrentIndex = async (
-    programShortName: string,
-    isPublic: boolean,
-  ): Promise<Index | undefined> => {
+  const fetchCurrentIndex = async (programShortName: string, isPublic: boolean): Promise<Index | undefined> => {
     logger.debug(`Fetching current index ${programShortName} isPublic:${isPublic}`);
     const url = urljoin(rootUrl, `/indices/resolved`);
 
     const shard = formatProgramShortName(programShortName);
 
+    // TODO: Data validation
     const response = (await fetch(url).then(res => res.json())) as Index[];
 
     const latestIndex = response
@@ -120,10 +117,7 @@ export default async (): Promise<RollCallClient> => {
 
   const fetchNextIndex = async (
     programShortName: string,
-    {
-      isPublic = false,
-      cloneFromReleasedIndex = false,
-    }: { isPublic: boolean; cloneFromReleasedIndex: boolean },
+    { isPublic = false, cloneFromReleasedIndex = false }: { isPublic: boolean; cloneFromReleasedIndex: boolean },
   ): Promise<Index> => {
     logger.info(
       `Fetching from Rollcall next index for ${programShortName}. Public=${isPublic}. Cloned=${cloneFromReleasedIndex}.`,
@@ -145,6 +139,8 @@ export default async (): Promise<RollCallClient> => {
         headers: { 'Content-Type': 'application/json' },
       }).then(res => res.json())) as Index;
 
+      // TODO: Data validation
+
       // Set the mapping and update settings
       await configureIndex(newIndex);
 
@@ -157,20 +153,18 @@ export default async (): Promise<RollCallClient> => {
   };
 
   const release = async (resovledIndex: Index): Promise<boolean> => {
-    logger.info(
-      `Requesting Rollcall to release index ${resovledIndex.indexName} to alias ${aliasName}`,
-    );
+    logger.info(`Requesting Rollcall to release index ${resovledIndex.indexName} to alias ${aliasName}`);
     const url = urljoin(`${rootUrl}`, `/aliases/release`);
 
     const req = await convertResolvedIndexToIndexReleaseRequest(resovledIndex);
 
-    const acknowledged = (await fetch(url, {
+    return await fetch(url, {
       method: 'POST',
       body: JSON.stringify(req),
       headers: { 'Content-Type': 'application/json' },
-    }).then(res => res.json())) as boolean;
-
-    return acknowledged;
+    })
+      .then(_ => true)
+      .catch(_ => false);
   };
 
   const configureIndex = async (index: Index): Promise<void> => {
@@ -192,9 +186,7 @@ export default async (): Promise<RollCallClient> => {
     }
   };
 
-  const convertResolvedIndexToIndexReleaseRequest = async (
-    resovledIndex: Index,
-  ): Promise<IndexReleaseRequest> => {
+  const convertResolvedIndexToIndexReleaseRequest = async (resovledIndex: Index): Promise<IndexReleaseRequest> => {
     const alias = aliasName;
     const shard = resovledIndex.shardPrefix + '_' + resovledIndex.shard;
     const release = resovledIndex.releasePrefix + '_' + resovledIndex.release;

--- a/src/jobs/processClinicalEvent.ts
+++ b/src/jobs/processClinicalEvent.ts
@@ -2,10 +2,10 @@ import { getAppConfig } from '../config';
 import * as fileService from '../data/files';
 
 import PromisePool from '@supercharge/promise-pool/dist';
-import { recalculateFileState } from '../services/fileManager';
+import ClinicalUpdateEvent from '../external/kafka/messages/ClinicalUpdateEvent';
+import { updateFileFromExternalSources } from '../services/fileManager';
 import { getIndexer } from '../services/indexer';
 import { isUnreleased } from '../services/utils/fileUtils';
-import ClinicalUpdateEvent from '../external/kafka/messages/ClinicalUpdateEvent';
 
 import Logger from '../logger';
 const logger = Logger('Job:ProcessClinicalEvent');
@@ -38,7 +38,7 @@ const clinicalUpdateEvent = async (clinicalEvent: ClinicalUpdateEvent): Promise<
         logger.error(`Update Doc Error: ${e.stack}`);
       })
       .process(async file => {
-        const updatedFile = await recalculateFileState(file);
+        const updatedFile = await updateFileFromExternalSources(file);
 
         if (updatedFile.releaseState !== fileService.FileReleaseState.UNRELEASED) {
           indexer.updateRestrictedFile(updatedFile);

--- a/src/jobs/recalculateFileEmbargo.ts
+++ b/src/jobs/recalculateFileEmbargo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
  *
  * This program and the accompanying materials are made available under the terms of
  * the GNU Affero General Public License v3.0. You should have received a copy of the
@@ -16,10 +16,10 @@
  * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-import Logger from '../logger';
 import * as fileService from '../data/files';
-import { recalculateFileState } from '../services/fileManager';
-import { getIndexer, Indexer } from '../services/indexer';
+import Logger from '../logger';
+import { updateFileFromExternalSources } from '../services/fileManager';
+import { Indexer, getIndexer } from '../services/indexer';
 const logger = Logger('Job:RecalculateFileEmbargo');
 
 async function recalculateFile(file: fileService.File, indexer: Indexer) {
@@ -32,7 +32,7 @@ async function recalculateFile(file: fileService.File, indexer: Indexer) {
       file.releaseState,
       file.embargoStart || '',
     );
-    const updatedFile = await recalculateFileState(file);
+    const updatedFile = await updateFileFromExternalSources(file);
 
     logger.debug(
       `updatedFile`,

--- a/src/services/fileManager.ts
+++ b/src/services/fileManager.ts
@@ -389,9 +389,3 @@ export async function fetchFileUpdatesFromDataCenter(files: File[]): Promise<Fil
 
   return output;
 }
-
-const x = ['a', 'b', 0, undefined];
-const y = x.filter(Boolean); // y is `(string | number | undefined)`
-
-const doesExist = <T>(input: T | undefined): input is T => Boolean(input);
-const z = x.filter(doesExist); // z is `(string | number)`

--- a/src/services/fileManager.ts
+++ b/src/services/fileManager.ts
@@ -202,7 +202,7 @@ export async function updateFileEmbargoState(file: File): Promise<File> {
         // A currently public file has been calculated as needing to be restricted
         // Record the calculated embargoStage but the file remains correctly listed as releaseState = PUBLIC
         logger.debug(
-          'recalculateFileState()',
+          'updateFileEmbargoState()',
           file.fileId,
           `PUBLIC file embargo calculated to be`,
           embargoStage,

--- a/src/services/fileManager.ts
+++ b/src/services/fileManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
  *
  * This program and the accompanying materials are made available under the terms of
  * the GNU Affero General Public License v3.0. You should have received a copy of the
@@ -34,7 +34,7 @@ import _ from 'lodash';
 
 import * as fileService from '../data/files';
 import { File, FileInput, EmbargoStage, FileReleaseState } from '../data/files';
-import * as maestro from '../external/analysisConverter';
+import * as analysisConverter from '../external/analysisConverter';
 import { RdpcFileDocument } from '../external/analysisConverter';
 import * as clinical from '../external/clinical';
 import * as song from '../external/song';
@@ -103,10 +103,11 @@ export async function saveAndIndexFilesFromRdpcData(
     await rdpcFileDocs.map(async rdpcFile => {
       // update local records
       const createdFile = await getOrCreateFileFromRdcData(rdpcFile, dataCenterId);
-      const updatedFile = await updateStatusFromRdpcData(createdFile, rdpcFile);
-      const fileWithUpdatedState = await recalculateFileState(updatedFile);
+      const partialUpdate = await updateStatusFromRdpcData(createdFile, rdpcFile);
+      const updatedFile = await updateFileFromExternalSources(partialUpdate);
+
       // convert to file centric documents
-      return buildDocument({ dbFile: fileWithUpdatedState, rdpcFile });
+      return buildDocument({ dbFile: updatedFile, rdpcFile });
     }),
   );
 
@@ -151,9 +152,10 @@ export async function getOrCheckFileEmbargoStart(file: File): Promise<Date | und
   //  - donor from clinical (to confirm the completion stats)
 
   try {
+    // TODO: The following requests need to be cached, otherwise they will be called repeatedly. Since file processing is being done in parallel and there are multiple files per donor
     const matchedSamplePairs = await dcGateway.getMatchedPairsForDonor(file.donorId);
     const songAnalysis = await song.getAnalysesById(file.repoId, file.programId, file.analysisId);
-    const clinicalDonor = await clinical.fetchDonor(file.programId, file.donorId);
+    const clinicalDonor = await clinical.getDonor(file.programId, file.donorId);
 
     const startDate = await calculateEmbargoStartDate({
       dbFile: file,
@@ -166,7 +168,7 @@ export async function getOrCheckFileEmbargoStart(file: File): Promise<Date | und
     }
     return startDate;
   } catch (e) {
-    logger.error(`Failure fetching source data while checking file's embargo start date: ${e}`);
+    logger.error(`Failure fetching source data while checking file's embargo start date`, e);
   }
 }
 
@@ -176,7 +178,7 @@ export async function getOrCheckFileEmbargoStart(file: File): Promise<Date | und
  * @param file
  * @returns
  */
-export async function recalculateFileState(file: File): Promise<File> {
+export async function updateFileEmbargoState(file: File): Promise<File> {
   // Check for embargoStart date, if not present  attempt to calculate it
 
   // Recalculate embargoStage
@@ -245,6 +247,44 @@ export async function recalculateFileState(file: File): Promise<File> {
   return file;
 }
 
+/**
+ * Check with clinical service if the file has had clinical data added, update the file, save to the DB
+ * and return the file with any changes.
+ * @param file
+ * @returns
+ */
+export async function updateFileClinicalData(file: File): Promise<File> {
+  if (file.hasClinicalData) {
+    // File already known to have clinical data, no changes necessary
+    return file;
+  }
+
+  try {
+    const donorData = await clinical.getDonor(file.programId, file.donorId);
+    if (donorData?.completionStats?.coreCompletionPercentage === 1) {
+      return await fileService.updateFileHasClinicalData(file.objectId, true);
+    }
+  } catch (error) {
+    logger.warn(`Failed to update file clinical data record`, file.programId, file.donorId, error);
+  }
+  return file;
+}
+
+/**
+ * Checks external sources for updates to file embargo state and clinical data state.
+ * This applies the following set of update functions:
+ *  - updateFileEmbargoState
+ *  - updateFileClinicalData
+ *
+ * The file is updated and saved to the DB and then the updated File is returned
+ * @param file
+ */
+export async function updateFileFromExternalSources(file: File): Promise<File> {
+  // TODO: The functions called here could use a refactoring to not perform DB updates in each step. We don't need the partial updates.
+  const partialUpdate = await updateFileEmbargoState(file);
+  return await updateFileClinicalData(partialUpdate);
+}
+
 type RdpcResultPair = {
   file: File;
   rdpcFile?: RdpcFileDocument;
@@ -253,6 +293,7 @@ type SortedRdpcResults = {
   dataCenterId: string;
   results: RdpcResultPair[];
 }[];
+
 /**
  * Given a list of files, fetch the updated file data for them from song
  * This is the data fetching step for updating db files from data center
@@ -296,7 +337,7 @@ export async function getRdpcDataForFiles(files: File[]): Promise<SortedRdpcResu
         });
     }
     // convert analyses documents to rdpcFileDocs
-    const rdpcFiles = await maestro.convertAnalysesToFileDocuments(retrievedAnalyses, dataCenterId);
+    const rdpcFiles = await analysisConverter.convertAnalysesToFileDocuments(retrievedAnalyses, dataCenterId);
 
     // Pair up the files in this data center with the rdpcFiles returned from maestro
     const results: RdpcResultPair[] = dcFiles.map(file => {
@@ -348,3 +389,9 @@ export async function fetchFileUpdatesFromDataCenter(files: File[]): Promise<Fil
 
   return output;
 }
+
+const x = ['a', 'b', 0, undefined];
+const y = x.filter(Boolean); // y is `(string | number | undefined)`
+
+const doesExist = <T>(input: T | undefined): input is T => Boolean(input);
+const z = x.filter(doesExist); // z is `(string | number)`

--- a/src/utils/asyncCache.ts
+++ b/src/utils/asyncCache.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+export type AsyncCache<Data, Inputs> = {
+  clear: (inputs: Inputs) => void;
+  get: (inputs: Inputs) => Promise<Data>;
+};
+
+export type FetchCache<T> =
+  | {
+      active: false;
+      data: T;
+      expiry: number;
+    }
+  | {
+      active: true;
+      promise: Promise<T>;
+    };
+
+/**
+ * Create an AsyncCache.
+ *
+ * An AsyncCache will store values returned by an async function (the `action`) for each unique set of inputs.
+ * On subsequent requests for the same set of inputs the stored value will be returned so that the work of the action
+ * does not need to be repeated.
+ *
+ * The AsyncCache will also track which async actions are in progress, so if a second request is made before the initial
+ * request is complete, the second requester will await for the original request to complete and then receive the same result.
+ *
+ * `options`:
+ * - `hashFunction`: A function that will convert the provided inputs into a unique string to use as the identifier of the request.
+ *                 The default hash function uses `JSON.stringify(inputs)`
+ * - `expirtyTime`: Time in miliseconds that the cached value will be kept for. The expiry timer starts after the initial action completes.
+ *
+ *
+ * @param action (inputs: Inputs) => Promise<Data>
+ * @param options {hashFunction?: (inputs: Inputs) => string; expiryTime?: number}
+ */
+const AsyncCache = <Data, Inputs>(
+  action: (inputs: Inputs) => Promise<Data>,
+  options?: { hashFunction?: (inputs: Inputs) => string; expiryTime?: number },
+): AsyncCache<Data, Inputs> => {
+  // apply defaults for undefined options
+  const _hashFunction = options?.hashFunction !== undefined ? options.hashFunction : (i: Inputs) => JSON.stringify(i);
+  const _expiryTime = options?.expiryTime !== undefined ? options.expiryTime : 60 * 1000 * 60; // One hour default expiry time
+
+  // initialize in memory cache
+  const CACHE: Record<string, FetchCache<Data>> = {};
+
+  // clear - remove cached value
+  const clear = (inputs: Inputs): void => {
+    const hash = _hashFunction(inputs);
+    delete CACHE['hash'];
+    return;
+  };
+
+  // get - cached action resolver
+  const get = async (inputs: Inputs): Promise<Data> => {
+    const hash = _hashFunction(inputs);
+
+    const actionWithCaching = async () => {
+      const promise = new Promise<Data>(async (resolve, _) => {
+        const response = await action(inputs);
+        CACHE[hash] = { active: false, data: response, expiry: Date.now() + _expiryTime };
+        resolve(response);
+      });
+      CACHE[hash] = { active: true, promise };
+      return promise;
+    };
+
+    const cacheHit = CACHE[hash] || undefined;
+
+    if (cacheHit) {
+      if (cacheHit.active) {
+        return cacheHit.promise;
+      } else if (cacheHit.expiry < Date.now()) {
+        return actionWithCaching();
+      } else {
+        return cacheHit.data;
+      }
+    } else {
+      return actionWithCaching();
+    }
+  };
+
+  return { clear, get };
+};
+export default AsyncCache;


### PR DESCRIPTION
## Objective

The file service should add to the file_centric indices a property to indicate that a file has available clinical data. This PR adds a boolean property to file_centric documents called `hasClinicalData` to accomplish this.

Whenever processing a file, before indexing, we will fetch donor information from the clinical service and record in the file DB collection if the file's donor has available clinical data.

### Bonus improvement (AsyncCache)
During development I noticed a lot of redundant calls to clinical for the same donor info, even before adding this additional check for clinical completeness. This is the result of having multiple files per analysis all referencing the same donor. To reduce the request traffic I added a caching utility that handles async requests. In addition to storing the results of async actions for a limited period of time it will prevent multiple concurrent requests.