### PR TITLE
Update Clinical API Type to accept incomplete core completion stats

### DIFF
--- a/src/external/clinical/types.ts
+++ b/src/external/clinical/types.ts
@@ -57,17 +57,19 @@ export const ClinicalDonor = zod.object({
     originalSchemaVersion: zod.string(),
     lastMigrationId: zod.string(),
   }),
-  completionStats: zod.object({
-    coreCompletion: zod.object({
-      donor: zod.number(),
-      specimens: zod.number(),
-      primaryDiagnosis: zod.number(),
-      followUps: zod.number(),
-      treatments: zod.number(),
-    }),
-    overriddenCoreCompletion: zod.array(zod.string()),
-    coreCompletionPercentage: zod.number(),
-    coreCompletionDate: zod.string(),
-  }),
+  completionStats: zod
+    .object({
+      coreCompletion: zod.object({
+        donor: zod.number(),
+        specimens: zod.number(),
+        primaryDiagnosis: zod.number(),
+        followUps: zod.number(),
+        treatments: zod.number(),
+      }),
+      overriddenCoreCompletion: zod.array(zod.string()),
+      coreCompletionPercentage: zod.number(),
+      coreCompletionDate: zod.string().nullable(),
+    })
+    .optional(),
 });
 export type ClinicalDonor = zod.infer<typeof ClinicalDonor>;

--- a/src/services/embargo.ts
+++ b/src/services/embargo.ts
@@ -203,7 +203,7 @@ export function calculateEmbargoStartDate(inputs: {
     .slice(-1)[0];
 
   // 3. clinical core completion date
-  const clinicalCoreCompletionDate = maybeDate(clinicalDonor?.completionStats.coreCompletionDate);
+  const clinicalCoreCompletionDate = maybeDate(clinicalDonor?.completionStats?.coreCompletionDate || undefined);
 
   if (analysisFirstPublished && (clinicalExemption || (matchedPairFirstPublished && clinicalCoreCompletionDate))) {
     const options: Date[] = [analysisFirstPublished];


### PR DESCRIPTION
Core incomplete donors caused parsing errors due to missing `coreCompletionDate` property. A review of database stats shows these changes should unblock the response validation for all donors.