### PR TITLE
Make concurrent operation pool sizes configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,7 +111,4 @@ ROLLCALL_FILE_ENTITY=file
 #################
 CLINICAL_URL=http://localhost:3000
 
-##################
-#  Feature Flags #
-##################
-FEATURE_CLINICAL_DATA_INDEXING=false
+

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,9 @@ import * as vault from './external/vault';
 import Logger from './logger';
 const logger = Logger('Config');
 
+// Initialize dotenv
+dotenv.config();
+
 let config: AppConfig | undefined = undefined;
 export interface AppConfig {
   serverPort: string;
@@ -217,11 +220,10 @@ export const getAppConfig = async (envFile?: string): Promise<AppConfig> => {
     return config;
   }
   if (envFile) {
+    // Allow dotenv to load from an alternate envFile
     dotenv.config({
       path: envFile,
     });
-  } else {
-    dotenv.config();
   }
   const secrets = await loadVaultSecrets();
   return buildAppConfig(secrets);

--- a/src/data/files/file.model.ts
+++ b/src/data/files/file.model.ts
@@ -19,7 +19,7 @@
 
 import mongoose, { PaginateModel } from 'mongoose';
 import { File } from 'winston/lib/winston/transports';
-import { FILE_PAGE_SIZE_LIMIT } from '../../config';
+import { envParameters } from '../../config';
 
 // Main reason for using this pagination plugin
 // is that it provides flexibility on pagination options such as
@@ -252,7 +252,7 @@ export async function getFilesQuery(
 ): Promise<mongoose.PaginateResult<FileMongooseDocument>> {
   const paginateOptions = {
     page: paginationFilters.page ? paginationFilters.page : 1,
-    limit: paginationFilters.limit ? paginationFilters.limit : FILE_PAGE_SIZE_LIMIT,
+    limit: paginationFilters.limit ? paginationFilters.limit : envParameters.fileModel.pageSizeLimit,
     sort: { fileId: 'asc' },
   };
 

--- a/src/external/analysisConverter.ts
+++ b/src/external/analysisConverter.ts
@@ -41,11 +41,9 @@ import fetch from 'node-fetch';
 import { SongAnalysis } from './song';
 import { getAlignmentMetrics } from './dataCenterGateway';
 
-import { getAppConfig } from '../config';
+import { envParameters, getAppConfig } from '../config';
 import Logger from '../logger';
 const logger = Logger('AnalysisConverter');
-
-const CONVERTER_CONCURRENT_REQUESTS = 5;
 
 const addMetricsToAlignedReadsFile = async (
   fileDocument: RdpcFileDocument,
@@ -83,7 +81,7 @@ export async function convertAnalysesToFileDocuments(
   const output: RdpcFileDocument[] = [];
 
   // Can't send hundreds of analyses in a single request, so this is simplified to 1 at a time to gaurantee success.
-  await PromisePool.withConcurrency(CONVERTER_CONCURRENT_REQUESTS)
+  await PromisePool.withConcurrency(envParameters.concurrency.analysisConverter.maxRequests)
     .for(analyses)
     .process(async analysis => {
       const files = await fetchAnalysisToFileConversion(analysis, repoCode);
@@ -115,7 +113,7 @@ async function fetchAnalysisToFileConversion(analysis: SongAnalysis, repoCode: s
   const files: RdpcFileDocument[] = [];
 
   // get the file docs arrays from maestro response
-  await PromisePool.withConcurrency(CONVERTER_CONCURRENT_REQUESTS)
+  await PromisePool.withConcurrency(envParameters.concurrency.analysisConverter.maxRequests)
     .for(Object.keys(response))
     .process(async (objectId: string) => {
       const responseFile = response[objectId][0];

--- a/src/jobs/processAnalysisEvent.ts
+++ b/src/jobs/processAnalysisEvent.ts
@@ -25,6 +25,7 @@ import * as fileService from '../data/files';
 import PromisePool from '@supercharge/promise-pool';
 
 import Logger from '../logger';
+import { envParameters } from '../config';
 const logger = Logger('Job:ProcessAnalysisEvent');
 
 async function handleSongPublishedAnalysis(analysis: any, dataCenterId: string) {
@@ -51,7 +52,7 @@ async function handleSongUnpublishedAnalysis(analysisId: string, status: string)
   }
 
   logger.info(`Updating Song status to ${status} for files ${files.map(file => file.objectId)}`);
-  await PromisePool.withConcurrency(10)
+  await PromisePool.withConcurrency(envParameters.concurrency.db.maxDocumentUpdates)
     .for(files)
     .handleError((error, file) => {
       logger.error(`Failure updating file ${file.objectId} status to ${status}: ${error}`);

--- a/src/routers/admin.ts
+++ b/src/routers/admin.ts
@@ -19,7 +19,7 @@
 
 import PromisePool from '@supercharge/promise-pool';
 import { Request, RequestHandler, Response, Router } from 'express';
-import { AppConfig } from '../config';
+import { AppConfig, envParameters } from '../config';
 import * as fileService from '../data/files';
 import reindexDataCenter from '../jobs/reindexDataCenter';
 import Logger, { unknownToString } from '../logger';
@@ -277,7 +277,7 @@ async function indexUpdatedFiles(updatedFiles: fileService.File[]) {
   const errors: Record<string, Error> = {};
   const indexer = await getIndexer();
   // Update file indices with changes
-  const { results } = await PromisePool.withConcurrency(20)
+  const { results } = await PromisePool.withConcurrency(envParameters.concurrency.elasticsearch.maxDocumentUpdates)
     .for(updatedFiles)
     .handleError((e, file) => {
       logger.error(`Update Doc Error: ${e}`);

--- a/src/services/release.ts
+++ b/src/services/release.ts
@@ -34,6 +34,7 @@ import { calculateEmbargoStage } from './embargo';
 import Logger from '../logger';
 import { isFilePublished } from './utils/fileUtils';
 import PublicReleaseMessage from '../external/kafka/messages/PublicReleaseMessage';
+import { envParameters } from '../config';
 const logger = Logger('ReleaseManager');
 
 function toObjectId(file: File) {
@@ -289,7 +290,7 @@ export async function publishActiveRelease(): Promise<void> {
 
     // 4. Update DB Release State for files updated in the release
     // 4a. DB Updates for added files
-    await PromisePool.withConcurrency(20)
+    await PromisePool.withConcurrency(envParameters.concurrency.db.maxDocumentUpdates)
       .for(release.filesAdded)
       .handleError((error, file) => {
         logger.error(`Failed to update release status in DB for ${file}`);
@@ -303,7 +304,7 @@ export async function publishActiveRelease(): Promise<void> {
     logger.debug(`File records in DB updated with new published states.`);
 
     // 4b. DB Updates for removed files
-    await PromisePool.withConcurrency(20)
+    await PromisePool.withConcurrency(envParameters.concurrency.db.maxDocumentUpdates)
       .for(updatedFilesRemoved)
       .handleError((error, file) => {
         logger.error(`Failed to update release status in DB for ${file}`);


### PR DESCRIPTION
Concurrent operations throughout the file manager use PromisePools that limit the maximum number of concurrent operations. These concurrency limits were originally hard coded in place. While the set values have worked, there are cases where the specific limits need tuning. In particular, concurrent requests to the RDPC for analysis data (SONG) can fail if too many requests are in flight, so this may need to be reduced in some environments.

This change makes all PromisePools pull their max concurrency value from a global config, and all the parameters provided by the config can be overwritten through the environment.

A utility method `getEnvNumberOrDefault` provides the process of pulling the environment variable, returning that value if it is a number (greater than 0), otherwise providing a default value.

Several concurrency pools use the same config because they are taking similar actions that should all be controlled through a single config property. For example, all of the operations that are creating and bulk writing to elasticsearch indices are controlled through the env parameter `CONCURRENCY_ES_INDEX_UPDATES`.

## New Env Properties
| Env Variable                           | Description                                                                                                                                  | Default |
| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
| `CONCURRENCY_ANALYSISCONVERTER_REQUESTS` | Max concurrent requests to make of the analysis converter (Maestro)                                                                          | 5       |
| `CONCURRENCY_DB_UPDATES`                | Max concurrent writes (document updates) to make to the mongo DB                                                                             | 10      |
| `CONCURRENCY_ES_DOC_UPDATES`             | Max concurrent requests for individual ElasticSearch document changes. This includes indexing, updating, or deleting an individual document. | 20      |
| `CONCURRENCY_ES_INDEX_UPDATES`           | Max concurrent requests to create, delte, or perform a bulk document update on an ElasticSearchS index.                                      | 5       |
| `CONCURRENCY_SONG_ANALYSIS_REQUESTS`     | Max concurrent requests to SONG for analysis data.                                                                                           | 10      |

## Other Changes
- Access secret values with `?.` operator in case the secrets come back undefined/null from vault request
- Remove unused feature in config for clinical data indexing