### PR TITLE
DonorCentric document is given all data from donor.clinicalData

### DIFF
--- a/src/external/clinical/types.ts
+++ b/src/external/clinical/types.ts
@@ -52,6 +52,7 @@ export const ClinicalDonor = zod
 		donorId: zod.string(),
 		gender: zod.string(),
 		programId: zod.string(),
+		clinicalData: zod.object({}).passthrough(),
 
 		submitterId: zod.string(),
 		createdAt: zod.string(),

--- a/src/services/donorCentric/donorCentricDocument.ts
+++ b/src/services/donorCentric/donorCentricDocument.ts
@@ -531,6 +531,7 @@ export function buildDonorCentricDocument({
 		submitter_donor_id: donor.submitterId,
 		study_id: donor.programId,
 		updated_at: donor.updatedAt,
+		...donor.clinicalData,
 
 		exposure: extractDonorExposureData(donor),
 		family_history: extractDonorFamilyHistoryData(donor),


### PR DESCRIPTION
DonorCentric documents were missing properties from the Donor entity. This change adds the donor clinicalData to each donor document.