### PR TITLE
#1283 Add missing properties to donor centric documents

### DIFF
--- a/src/external/song.ts
+++ b/src/external/song.ts
@@ -67,7 +67,17 @@ const songFileSchema = zod
 		fileAccess: zod.string(),
 		dataType: zod.string(),
 		info: zod
-			.object({})
+			.object({
+				data_category: zod.string().optional(),
+				analysis_tools: zod
+					.string()
+					.array()
+					.optional(),
+			})
+			.passthrough()
+			.optional(),
+		workflow: zod
+			.object({ workflow_name: zod.string().optional(), workflow_version: zod.string().optional() })
 			.passthrough()
 			.optional(),
 	})

--- a/src/resources/donor-centric-index-mapping.json
+++ b/src/resources/donor-centric-index-mapping.json
@@ -349,7 +349,7 @@
 			"follow_ups": {
 				"type": "nested",
 				"properties": {
-					"anatomic_site_progression_or_recurrences": {
+					"anatomic_site_progression_or_recurrence": {
 						"type": "keyword"
 					},
 					"disease_status_at_followup": {


### PR DESCRIPTION
Corrects indexing of fields that were missing in Donor Centric Index:
- Specimen fields that needed naming case correction from root document
- Typo on mapping for `follow_up.anatomic_site_progression_or_recurrence`
- Missing file properties from song analysis, including nested workflow fields